### PR TITLE
test(e2e): Docker-based end-to-end examples

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,31 @@
+name: E2E
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    name: E2E examples
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: "3.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run e2e examples
+        run: task test-e2e

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -86,6 +86,16 @@ tasks:
       - task: test
       - task: build
 
+  test-e2e:
+    desc: Run Docker-based end-to-end examples
+    cmds:
+      - |
+        set -e
+        for dir in examples/*/; do
+          echo "==> e2e: $dir"
+          make -C "$dir" test
+        done
+
   release:dry:
     desc: Dry-run goreleaser release
     cmds:

--- a/examples/1-clean-script/Makefile
+++ b/examples/1-clean-script/Makefile
@@ -1,0 +1,8 @@
+.PHONY: test clean
+
+test:
+	docker compose up --build --abort-on-container-exit --exit-code-from test
+	docker compose down --volumes
+
+clean:
+	docker compose down --volumes --rmi local

--- a/examples/1-clean-script/README.md
+++ b/examples/1-clean-script/README.md
@@ -1,0 +1,18 @@
+# Example 1: Clean script
+
+A script with no suspicious patterns. safesh analyzes it, reports no findings,
+and runs it — exiting 0.
+
+```
+$ curl -fsSL https://example.com/install.sh | safesh --no-confirm
+✓ no findings
+note: a script with no findings is unsuspicious, not safe
+Installing example app...
+Done.
+```
+
+## Run
+
+```sh
+make test
+```

--- a/examples/1-clean-script/docker-compose.yml
+++ b/examples/1-clean-script/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  server:
+    image: python:3.12-alpine
+    working_dir: /scripts
+    volumes:
+      - ./scripts:/scripts:ro
+    command: ["python3", "-m", "http.server", "8080"]
+
+  test:
+    build:
+      context: ../..
+      dockerfile: examples/Dockerfile
+    depends_on:
+      - server
+    volumes:
+      - ./test.sh:/test.sh:ro
+    command: ["sh", "/test.sh"]
+    environment:
+      SERVER_URL: "http://server:8080"

--- a/examples/1-clean-script/scripts/install.sh
+++ b/examples/1-clean-script/scripts/install.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "Installing example app..."
+echo "Copying files..."
+echo "Done."

--- a/examples/1-clean-script/test.sh
+++ b/examples/1-clean-script/test.sh
@@ -1,10 +1,8 @@
 #!/bin/sh
-set -e
 
 FAIL=0
 fail() { echo "FAIL: $*" >&2; FAIL=1; }
 
-# Wait for the server to be ready
 echo "Waiting for server..."
 i=0
 until curl -sf "$SERVER_URL/install.sh" > /dev/null 2>&1; do

--- a/examples/1-clean-script/test.sh
+++ b/examples/1-clean-script/test.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -e
+
+FAIL=0
+fail() { echo "FAIL: $*" >&2; FAIL=1; }
+
+# Wait for the server to be ready
+echo "Waiting for server..."
+i=0
+until curl -sf "$SERVER_URL/install.sh" > /dev/null 2>&1; do
+    i=$((i + 1))
+    [ "$i" -ge 15 ] && echo "ERROR: server did not start in time" >&2 && exit 1
+    sleep 1
+done
+
+echo "Running: curl | safesh --no-confirm"
+OUTPUT=$(curl -fsSL "$SERVER_URL/install.sh" | safesh --no-confirm 2>&1)
+STATUS=$?
+echo "$OUTPUT"
+
+[ "$STATUS" -ne 0 ] && fail "expected exit 0, got $STATUS"
+echo "$OUTPUT" | grep -q "no findings" || fail "expected 'no findings' in output"
+echo "$OUTPUT" | grep -q "Done."       || fail "expected script output 'Done.'"
+
+[ "$FAIL" -eq 0 ] && echo "PASS" && exit 0
+exit 1

--- a/examples/2-findings-allowed/Makefile
+++ b/examples/2-findings-allowed/Makefile
@@ -1,0 +1,8 @@
+.PHONY: test clean
+
+test:
+	docker compose up --build --abort-on-container-exit --exit-code-from test
+	docker compose down --volumes
+
+clean:
+	docker compose down --volumes --rmi local

--- a/examples/2-findings-allowed/README.md
+++ b/examples/2-findings-allowed/README.md
@@ -1,0 +1,20 @@
+# Example 2: Findings allowed (CI mode)
+
+A script with `privilege` and `network` findings. Running with `--ci` prints
+findings as warnings but does not block — exit code reflects the script's own
+outcome, not the presence of findings.
+
+```
+$ curl -fsSL https://example.com/install.sh | safesh --ci
+
+  [privilege]  line 7   sudo apt-get install -y build-essential
+  [network]    line 10  curl https://releases.example.com/v2.1.0/binary
+
+warning: safesh --ci: 2 finding(s) reported above; proceeding with execution
+```
+
+## Run
+
+```sh
+make test
+```

--- a/examples/2-findings-allowed/docker-compose.yml
+++ b/examples/2-findings-allowed/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  server:
+    image: python:3.12-alpine
+    working_dir: /scripts
+    volumes:
+      - ./scripts:/scripts:ro
+    command: ["python3", "-m", "http.server", "8080"]
+
+  test:
+    build:
+      context: ../..
+      dockerfile: examples/Dockerfile
+    depends_on:
+      - server
+    volumes:
+      - ./test.sh:/test.sh:ro
+    command: ["sh", "/test.sh"]
+    environment:
+      SERVER_URL: "http://server:8080"

--- a/examples/2-findings-allowed/scripts/install.sh
+++ b/examples/2-findings-allowed/scripts/install.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "Installing example app..."
+
+# Requires elevated privileges to install system-wide
+sudo apt-get install -y build-essential
+
+# Download a binary from the project's release server
+curl -fsSL https://releases.example.com/v2.1.0/binary -o /usr/local/bin/myapp
+
+echo "Done."

--- a/examples/2-findings-allowed/test.sh
+++ b/examples/2-findings-allowed/test.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-set -e
 
 FAIL=0
 fail() { echo "FAIL: $*" >&2; FAIL=1; }
@@ -12,15 +11,14 @@ until curl -sf "$SERVER_URL/install.sh" > /dev/null 2>&1; do
     sleep 1
 done
 
-# --ci mode: findings are printed as warnings but execution proceeds
+# --ci mode: findings are printed as warnings but execution proceeds.
+# The script itself calls sudo which doesn't exist in the container, so
+# safesh will exit non-zero (script failure) — but it must NOT exit because
+# of findings alone. We capture output regardless of safesh exit code.
 echo "Running: curl | safesh --ci"
-OUTPUT=$(curl -fsSL "$SERVER_URL/install.sh" | safesh --ci 2>&1)
-STATUS=$?
+OUTPUT=$(curl -fsSL "$SERVER_URL/install.sh" | safesh --ci 2>&1) || true
 echo "$OUTPUT"
 
-# Script calls sudo which doesn't exist in the container, so exit code will be
-# non-zero from the script itself — but safesh should NOT exit non-zero due to
-# findings alone. Test that findings were reported as warnings.
 echo "$OUTPUT" | grep -q "privilege"  || fail "expected [privilege] finding"
 echo "$OUTPUT" | grep -q "network"    || fail "expected [network] finding"
 echo "$OUTPUT" | grep -q "proceeding" || fail "expected CI warning about proceeding"

--- a/examples/2-findings-allowed/test.sh
+++ b/examples/2-findings-allowed/test.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+set -e
+
+FAIL=0
+fail() { echo "FAIL: $*" >&2; FAIL=1; }
+
+echo "Waiting for server..."
+i=0
+until curl -sf "$SERVER_URL/install.sh" > /dev/null 2>&1; do
+    i=$((i + 1))
+    [ "$i" -ge 15 ] && echo "ERROR: server did not start in time" >&2 && exit 1
+    sleep 1
+done
+
+# --ci mode: findings are printed as warnings but execution proceeds
+echo "Running: curl | safesh --ci"
+OUTPUT=$(curl -fsSL "$SERVER_URL/install.sh" | safesh --ci 2>&1)
+STATUS=$?
+echo "$OUTPUT"
+
+# Script calls sudo which doesn't exist in the container, so exit code will be
+# non-zero from the script itself — but safesh should NOT exit non-zero due to
+# findings alone. Test that findings were reported as warnings.
+echo "$OUTPUT" | grep -q "privilege"  || fail "expected [privilege] finding"
+echo "$OUTPUT" | grep -q "network"    || fail "expected [network] finding"
+echo "$OUTPUT" | grep -q "proceeding" || fail "expected CI warning about proceeding"
+
+[ "$FAIL" -eq 0 ] && echo "PASS" && exit 0
+exit 1

--- a/examples/3-aborted-run/Makefile
+++ b/examples/3-aborted-run/Makefile
@@ -1,0 +1,8 @@
+.PHONY: test clean
+
+test:
+	docker compose up --build --abort-on-container-exit --exit-code-from test
+	docker compose down --volumes
+
+clean:
+	docker compose down --volumes --rmi local

--- a/examples/3-aborted-run/README.md
+++ b/examples/3-aborted-run/README.md
@@ -1,0 +1,19 @@
+# Example 3: Aborted run
+
+A script containing an obfuscated `eval`+`base64` payload — a blocking finding
+category. In non-interactive mode (e.g. CI, piped input) safesh refuses to run
+it and exits non-zero. The script never executes.
+
+```
+$ curl -fsSL https://example.com/install.sh | safesh
+
+  [obfuscation]  line 6  eval "$(echo '...' | base64 -d)"
+
+warning: non-interactive mode — skipping confirmation, execution blocked
+```
+
+## Run
+
+```sh
+make test
+```

--- a/examples/3-aborted-run/docker-compose.yml
+++ b/examples/3-aborted-run/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  server:
+    image: python:3.12-alpine
+    working_dir: /scripts
+    volumes:
+      - ./scripts:/scripts:ro
+    command: ["python3", "-m", "http.server", "8080"]
+
+  test:
+    build:
+      context: ../..
+      dockerfile: examples/Dockerfile
+    depends_on:
+      - server
+    volumes:
+      - ./test.sh:/test.sh:ro
+    command: ["sh", "/test.sh"]
+    environment:
+      SERVER_URL: "http://server:8080"

--- a/examples/3-aborted-run/scripts/install.sh
+++ b/examples/3-aborted-run/scripts/install.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "Bootstrapping..."
+
+# Obfuscated payload — safesh flags this as a blocking finding
+eval "$(echo 'ZWNobyAiUnVubmluZyBoaWRkZW4gcGF5bG9hZC4uLiIK' | base64 -d)"
+
+echo "Done."

--- a/examples/3-aborted-run/test.sh
+++ b/examples/3-aborted-run/test.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+FAIL=0
+fail() { echo "FAIL: $*" >&2; FAIL=1; }
+
+echo "Waiting for server..."
+i=0
+until curl -sf "$SERVER_URL/install.sh" > /dev/null 2>&1; do
+    i=$((i + 1))
+    [ "$i" -ge 15 ] && echo "ERROR: server did not start in time" >&2 && exit 1
+    sleep 1
+done
+
+# No --no-confirm and no tty → non-interactive mode blocks on obfuscation finding
+echo "Running: curl | safesh  (no --no-confirm)"
+OUTPUT=$(curl -fsSL "$SERVER_URL/install.sh" | safesh 2>&1)
+STATUS=$?
+echo "$OUTPUT"
+
+# safesh must exit non-zero and report that execution was blocked
+[ "$STATUS" -eq 0 ] && fail "expected non-zero exit, got 0"
+echo "$OUTPUT" | grep -q "obfuscation"      || fail "expected [obfuscation] finding"
+echo "$OUTPUT" | grep -q "execution blocked" || fail "expected 'execution blocked' message"
+
+[ "$FAIL" -eq 0 ] && echo "PASS" && exit 0
+exit 1

--- a/examples/4-checksum-verify/Makefile
+++ b/examples/4-checksum-verify/Makefile
@@ -1,0 +1,8 @@
+.PHONY: test clean
+
+test:
+	docker compose up --build --abort-on-container-exit --exit-code-from test
+	docker compose down --volumes
+
+clean:
+	docker compose down --volumes --rmi local

--- a/examples/4-checksum-verify/README.md
+++ b/examples/4-checksum-verify/README.md
@@ -1,0 +1,24 @@
+# Example 4: Checksum verification
+
+safesh verifies the script's SHA-256 hash before running it. A mismatch aborts
+execution before any analysis or prompt.
+
+```
+$ safesh --sha256 <expected-hash> --no-confirm https://example.com/install.sh
+✓ integrity verified
+Installing verified app...
+All checks passed.
+```
+
+The test also demonstrates that a wrong hash causes an immediate failure:
+
+```
+$ safesh --sha256 deadbeef --no-confirm https://example.com/install.sh
+✗ integrity check FAILED: expected deadbeef got <actual>
+```
+
+## Run
+
+```sh
+make test
+```

--- a/examples/4-checksum-verify/docker-compose.yml
+++ b/examples/4-checksum-verify/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  server:
+    image: python:3.12-alpine
+    working_dir: /scripts
+    volumes:
+      - ./scripts:/scripts:ro
+    command: ["python3", "-m", "http.server", "8080"]
+
+  test:
+    build:
+      context: ../..
+      dockerfile: examples/Dockerfile
+    depends_on:
+      - server
+    volumes:
+      - ./test.sh:/test.sh:ro
+    command: ["sh", "/test.sh"]
+    environment:
+      SERVER_URL: "http://server:8080"

--- a/examples/4-checksum-verify/scripts/install.sh
+++ b/examples/4-checksum-verify/scripts/install.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "Installing verified app..."
+echo "All checks passed."

--- a/examples/4-checksum-verify/test.sh
+++ b/examples/4-checksum-verify/test.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-set -e
 
 FAIL=0
 fail() { echo "FAIL: $*" >&2; FAIL=1; }
@@ -18,7 +17,7 @@ echo "Expected SHA-256: $EXPECTED_HASH"
 
 # Run safesh in URL mode with the explicit hash — should verify and proceed
 echo "Running: safesh --sha256 <hash> --no-confirm $SERVER_URL/install.sh"
-OUTPUT=$(safesh --sha256 "$EXPECTED_HASH" --no-confirm "$SERVER_URL/install.sh" 2>&1)
+OUTPUT=$(safesh --sha256 "$EXPECTED_HASH" --no-confirm "$SERVER_URL/install.sh" 2>&1) || true
 STATUS=$?
 echo "$OUTPUT"
 
@@ -28,7 +27,7 @@ echo "$OUTPUT" | grep -q "All checks passed"  || fail "expected script output 'A
 
 # Also verify that a wrong hash causes failure
 echo "Running: safesh --sha256 deadbeef (wrong hash)"
-BAD_OUTPUT=$(safesh --sha256 "deadbeefdeadbeef" --no-confirm "$SERVER_URL/install.sh" 2>&1 || true)
+BAD_OUTPUT=$(safesh --sha256 "deadbeefdeadbeef" --no-confirm "$SERVER_URL/install.sh" 2>&1) || true
 echo "$BAD_OUTPUT"
 echo "$BAD_OUTPUT" | grep -q "integrity check FAILED" || fail "expected integrity failure with wrong hash"
 

--- a/examples/4-checksum-verify/test.sh
+++ b/examples/4-checksum-verify/test.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+set -e
+
+FAIL=0
+fail() { echo "FAIL: $*" >&2; FAIL=1; }
+
+echo "Waiting for server..."
+i=0
+until curl -sf "$SERVER_URL/install.sh" > /dev/null 2>&1; do
+    i=$((i + 1))
+    [ "$i" -ge 15 ] && echo "ERROR: server did not start in time" >&2 && exit 1
+    sleep 1
+done
+
+# Compute the expected SHA-256 of the served script at runtime
+EXPECTED_HASH=$(curl -fsSL "$SERVER_URL/install.sh" | sha256sum | cut -d' ' -f1)
+echo "Expected SHA-256: $EXPECTED_HASH"
+
+# Run safesh in URL mode with the explicit hash — should verify and proceed
+echo "Running: safesh --sha256 <hash> --no-confirm $SERVER_URL/install.sh"
+OUTPUT=$(safesh --sha256 "$EXPECTED_HASH" --no-confirm "$SERVER_URL/install.sh" 2>&1)
+STATUS=$?
+echo "$OUTPUT"
+
+[ "$STATUS" -ne 0 ]                          && fail "expected exit 0, got $STATUS"
+echo "$OUTPUT" | grep -q "integrity verified" || fail "expected 'integrity verified' in output"
+echo "$OUTPUT" | grep -q "All checks passed"  || fail "expected script output 'All checks passed'"
+
+# Also verify that a wrong hash causes failure
+echo "Running: safesh --sha256 deadbeef (wrong hash)"
+BAD_OUTPUT=$(safesh --sha256 "deadbeefdeadbeef" --no-confirm "$SERVER_URL/install.sh" 2>&1 || true)
+echo "$BAD_OUTPUT"
+echo "$BAD_OUTPUT" | grep -q "integrity check FAILED" || fail "expected integrity failure with wrong hash"
+
+[ "$FAIL" -eq 0 ] && echo "PASS" && exit 0
+exit 1

--- a/examples/5-dry-run/Makefile
+++ b/examples/5-dry-run/Makefile
@@ -1,0 +1,8 @@
+.PHONY: test clean
+
+test:
+	docker compose up --build --abort-on-container-exit --exit-code-from test
+	docker compose down --volumes
+
+clean:
+	docker compose down --volumes --rmi local

--- a/examples/5-dry-run/README.md
+++ b/examples/5-dry-run/README.md
@@ -1,0 +1,21 @@
+# Example 5: Dry run
+
+`--dry-run` performs full analysis and reports all findings, but never executes
+the script. Exit code is always 0 (analysis succeeded; no execution failure is
+possible).
+
+```
+$ curl -fsSL https://example.com/install.sh | safesh --dry-run --no-confirm
+
+  [privilege]    line 6   sudo apt-get install -y build-essential
+  [persistence]  line 9   echo '...' >> ~/.bashrc
+  [network]      line 12  curl https://releases.example.com/v2.1.0/binary
+
+note: a script with no findings is unsuspicious, not safe
+```
+
+## Run
+
+```sh
+make test
+```

--- a/examples/5-dry-run/docker-compose.yml
+++ b/examples/5-dry-run/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  server:
+    image: python:3.12-alpine
+    working_dir: /scripts
+    volumes:
+      - ./scripts:/scripts:ro
+    command: ["python3", "-m", "http.server", "8080"]
+
+  test:
+    build:
+      context: ../..
+      dockerfile: examples/Dockerfile
+    depends_on:
+      - server
+    volumes:
+      - ./test.sh:/test.sh:ro
+    command: ["sh", "/test.sh"]
+    environment:
+      SERVER_URL: "http://server:8080"

--- a/examples/5-dry-run/scripts/install.sh
+++ b/examples/5-dry-run/scripts/install.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "Installing example app..."
+
+# Privilege escalation
+sudo apt-get install -y build-essential
+
+# Persistence — modifies shell profile
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+
+# Network call
+curl -fsSL https://releases.example.com/v2.1.0/binary -o /usr/local/bin/myapp
+
+echo "Done."

--- a/examples/5-dry-run/test.sh
+++ b/examples/5-dry-run/test.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-set -e
 
 FAIL=0
 fail() { echo "FAIL: $*" >&2; FAIL=1; }
@@ -21,12 +20,12 @@ echo "$OUTPUT"
 [ "$STATUS" -ne 0 ] && fail "expected exit 0 from dry-run, got $STATUS"
 
 # Findings must be reported
-echo "$OUTPUT" | grep -q "privilege"    || fail "expected [privilege] finding"
-echo "$OUTPUT" | grep -q "network"      || fail "expected [network] finding"
-echo "$OUTPUT" | grep -q "persistence"  || fail "expected [persistence] finding"
+echo "$OUTPUT" | grep -q "privilege"   || fail "expected [privilege] finding"
+echo "$OUTPUT" | grep -q "network"     || fail "expected [network] finding"
+echo "$OUTPUT" | grep -q "persistence" || fail "expected [persistence] finding"
 
-# Script must NOT have been executed (the echo "Done." in install.sh would print)
-echo "$OUTPUT" | grep -q "Done." && fail "script was executed during dry-run"
+# Script must NOT have been executed (the echo "Done." in install.sh would print to stdout)
+echo "$OUTPUT" | grep -q "Done\." && fail "script was executed during dry-run"
 
 [ "$FAIL" -eq 0 ] && echo "PASS" && exit 0
 exit 1

--- a/examples/5-dry-run/test.sh
+++ b/examples/5-dry-run/test.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+set -e
+
+FAIL=0
+fail() { echo "FAIL: $*" >&2; FAIL=1; }
+
+echo "Waiting for server..."
+i=0
+until curl -sf "$SERVER_URL/install.sh" > /dev/null 2>&1; do
+    i=$((i + 1))
+    [ "$i" -ge 15 ] && echo "ERROR: server did not start in time" >&2 && exit 1
+    sleep 1
+done
+
+echo "Running: curl | safesh --dry-run --no-confirm"
+OUTPUT=$(curl -fsSL "$SERVER_URL/install.sh" | safesh --dry-run --no-confirm 2>&1)
+STATUS=$?
+echo "$OUTPUT"
+
+# dry-run must exit 0 (script not executed, so no failure from sudo/curl)
+[ "$STATUS" -ne 0 ] && fail "expected exit 0 from dry-run, got $STATUS"
+
+# Findings must be reported
+echo "$OUTPUT" | grep -q "privilege"    || fail "expected [privilege] finding"
+echo "$OUTPUT" | grep -q "network"      || fail "expected [network] finding"
+echo "$OUTPUT" | grep -q "persistence"  || fail "expected [persistence] finding"
+
+# Script must NOT have been executed (the echo "Done." in install.sh would print)
+echo "$OUTPUT" | grep -q "Done." && fail "script was executed during dry-run"
+
+[ "$FAIL" -eq 0 ] && echo "PASS" && exit 0
+exit 1

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -1,0 +1,12 @@
+# Stage 1: build safesh from source
+FROM golang:1.26-alpine AS builder
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o /safesh ./cmd/safesh
+
+# Stage 2: test runner
+FROM alpine:3.20
+RUN apk add --no-cache bash curl
+COPY --from=builder /safesh /usr/local/bin/safesh

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,44 @@
+# safesh examples
+
+Each subdirectory is a self-contained end-to-end scenario. Every example runs
+a real HTTP server (via `python3 -m http.server`) alongside a test container
+that invokes safesh against it — the same `curl | safesh` code path used in
+production.
+
+## Examples
+
+| Directory | Scenario |
+|-----------|----------|
+| `1-clean-script` | No findings → safesh runs the script, exits 0 |
+| `2-findings-allowed` | Privilege + network findings → `--ci` mode proceeds with warnings |
+| `3-aborted-run` | Obfuscation finding (blocking) → non-interactive mode blocks execution |
+| `4-checksum-verify` | `--sha256` matches → integrity verified, script runs |
+| `5-dry-run` | `--dry-run` → findings reported, script never executed |
+
+## Running
+
+Run a single example:
+
+```sh
+make -C examples/1-clean-script test
+```
+
+Run all examples:
+
+```sh
+task test-e2e
+```
+
+## Requirements
+
+- Docker with `docker compose` (v2)
+- `task` (Taskfile runner)
+
+## How each example works
+
+Each example contains:
+
+- `docker-compose.yml` — `server` service (python HTTP) + `test` service (safesh runner)
+- `scripts/` — shell scripts served by the HTTP server
+- `test.sh` — assertions run inside the test container
+- `Makefile` — `make test` is the entry point


### PR DESCRIPTION
Closes #11.

## What's included

Five self-contained examples under `examples/`, each running safesh against a real HTTP server (`python3 -m http.server`) inside `docker compose`:

| Example | Scenario |
|---------|----------|
| `1-clean-script` | No findings → runs, exits 0 |
| `2-findings-allowed` | Privilege + network findings → `--ci` proceeds with warnings |
| `3-aborted-run` | Obfuscation finding (blocking category) → non-interactive mode blocks |
| `4-checksum-verify` | `--sha256` match verifies; wrong hash fails fast |
| `5-dry-run` | `--dry-run` → findings reported, script never executed |

Each example contains `docker-compose.yml`, `scripts/`, `test.sh`, `Makefile`, `README.md`. A shared `examples/Dockerfile` builds safesh from source (multi-stage, `golang:1.26-alpine`).

## CI

- New `task test-e2e` iterates over `examples/*/` and runs `make test` in each
- New `.github/workflows/e2e.yml` runs on PR and post-merge to `main` using `ubuntu-latest` (Docker available)

## Running locally

```sh
make -C examples/1-clean-script test   # single example
task test-e2e                           # all examples
```