### PR TITLE
feat(cli): add --version flag mirroring 'version' subcommand

### DIFF
--- a/cmd/safesh/main.go
+++ b/cmd/safesh/main.go
@@ -62,6 +62,7 @@ Usage:
   curl -fsSL https://example.com/install.sh | safesh bash
   safesh https://example.com/install.sh
   safesh --dry-run https://example.com/install.sh`,
+		Version:       fmt.Sprintf("%s (commit %s, built %s)", version, commit, date),
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		Args:          cobra.MaximumNArgs(1),
@@ -69,6 +70,7 @@ Usage:
 			return runMain(cmd, args, f)
 		},
 	}
+	root.SetVersionTemplate("safesh {{.Version}}\n")
 
 	root.PersistentFlags().BoolVar(&f.dryRun, "dry-run", false, "analyse without executing")
 	root.PersistentFlags().BoolVar(&f.observe, "observe", false, "run script under strace and report observed behaviour (Linux only, requires strace)")


### PR DESCRIPTION
## Summary
- Adds `--version` flag to `safesh` so it mirrors the existing `safesh version` subcommand. Both produce identical output.
- Wired via cobra's built-in `Version` field plus a custom `SetVersionTemplate` so the format stays consistent with the existing subcommand: `safesh <ver> (commit <c>, built <d>)`.
- No short flag (`-v`/`-V`) bound — long-only avoids future collision.

## Test plan
- [x] `go build` succeeds with goreleaser-style ldflags
- [x] `safesh version` and `safesh --version` produce identical output (verified locally)
- [x] `go test -race -count=1 ./...` — all 11 packages pass
- [x] `golangci-lint run ./...` — no new issues (one pre-existing S1039 in `internal/sandbox/sandbox_other.go` is unchanged and out of scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)