### PR TITLE
fix(e2e): update checksum-verify test greps to match current safesh output

### DIFF
--- a/examples/4-checksum-verify/test.sh
+++ b/examples/4-checksum-verify/test.sh
@@ -22,14 +22,14 @@ STATUS=$?
 echo "$OUTPUT"
 
 [ "$STATUS" -ne 0 ]                          && fail "expected exit 0, got $STATUS"
-echo "$OUTPUT" | grep -q "integrity verified" || fail "expected 'integrity verified' in output"
+echo "$OUTPUT" | grep -q "sha256 verified" || fail "expected 'sha256 verified' in output"
 echo "$OUTPUT" | grep -q "All checks passed"  || fail "expected script output 'All checks passed'"
 
 # Also verify that a wrong hash causes failure
 echo "Running: safesh --sha256 deadbeef (wrong hash)"
 BAD_OUTPUT=$(safesh --sha256 "deadbeefdeadbeef" --no-confirm "$SERVER_URL/install.sh" 2>&1) || true
 echo "$BAD_OUTPUT"
-echo "$BAD_OUTPUT" | grep -q "integrity check FAILED" || fail "expected integrity failure with wrong hash"
+echo "$BAD_OUTPUT" | grep -q "integrity check failed" || fail "expected integrity failure with wrong hash"
 
 [ "$FAIL" -eq 0 ] && echo "PASS" && exit 0
 exit 1


### PR DESCRIPTION
## Summary

The `examples/4-checksum-verify` E2E job has been failing on every push to main for the last several runs. Cause: the grep assertions in `test.sh` look for legacy phrasing the safesh binary no longer emits.

| Step                | Test greps for         | Binary actually emits     |
|---------------------|------------------------|---------------------------|
| Success path        | `integrity verified`   | `sha256 verified`         |
| Wrong-hash path     | `integrity check FAILED` (caps) | `integrity check failed` (lowercase) |

This PR updates the two greps to match. No production code changes.

## Test plan
- [x] Greps verified against actual CI output of run 25622109702
- [ ] CI E2E job goes green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)