### PR TITLE
docs: sync README and site with current code surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ safesh history show <id>
 | `network` | Outbound `curl`/`wget` calls and their domains |
 | `obfuscation` | `eval`, `base64 -d \| bash` chains |
 | `execution-chain` | Nested `curl \| bash` inside the script |
+| `homograph` | Bidi/zero-width characters and IDN-homograph URL hosts |
 
 ## Philosophy
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -152,6 +152,7 @@ Modules are stateless and run in parallel. Results are merged and sorted by line
 | `network` | `CallExpr` where command is `curl`, `wget`, `fetch`, `http`; extracts literal URL arguments |
 | `obfuscation` | `CallExpr` for `eval`; pipe expressions where left side is `base64` with decode flags and right side is a shell |
 | `execution-chain` | Pipe expressions where the right-hand command is `bash`, `sh`, `zsh`, `dash`, `fish`, or `ksh` |
+| `homograph` | Bidi/isolate control characters (RLO, LRO, FSI, …), zero-width characters (ZWSP, ZWJ, ZWNJ, BOM), and URL hosts with non-ASCII or mixed-script labels (IDN homograph) |
 
 #### A note on static analysis limits
 
@@ -388,6 +389,10 @@ safesh history clean [flags]      # remove history entries matching criteria
 | `--env <VAR>` | Pass through a named environment variable (repeatable) |
 | `--no-strict` | Do not inject `set -euo pipefail` |
 | `--no-confirm` | Display findings but do not prompt; always proceed |
+| `--ci` | CI mode: skip prompt, print findings as warnings, exit non-zero only on execution failure |
+| `--sandbox` | Run script inside a bubblewrap sandbox (Linux only, requires `bwrap`) |
+| `--sandbox-allow-net` | Allow network access inside the sandbox (default: network is blocked) |
+| `--observe` | Run script under `strace` and report observed behavior (Linux only, requires `strace`) |
 | `--config <path>` | Use an alternate config file |
 | `--version` | Print version and exit |
 | `--help` | Print help and exit |
@@ -424,11 +429,12 @@ safesh/
 ├── internal/
 │   ├── analyzer/
 │   │   ├── analyzer.go           # orchestrates module execution
-│   │   ├── finding.go            # Finding type and Category constants
 │   │   └── modules/
 │   │       ├── destructive.go
 │   │       ├── execution_chain.go
 │   │       ├── execution_integrity.go
+│   │       ├── helpers.go
+│   │       ├── homograph.go
 │   │       ├── network.go
 │   │       ├── obfuscation.go
 │   │       ├── persistence.go
@@ -439,10 +445,17 @@ safesh/
 │   │   └── executor.go           # preamble injection, env setup, shell delegation
 │   ├── fetcher/
 │   │   └── fetcher.go            # stdin reader and HTTPS fetcher
+│   ├── finding/
+│   │   └── finding.go            # Finding type and Category constants (separate package to avoid import cycles with modules)
 │   ├── history/
 │   │   └── history.go            # write and read history entries
+│   ├── integration/              # end-to-end tests (build tag: integration)
 │   ├── integrity/
 │   │   └── integrity.go          # checksum discovery and verification
+│   ├── observer/
+│   │   └── observer.go           # strace-based runtime observation (--observe)
+│   ├── sandbox/
+│   │   └── sandbox.go            # bubblewrap sandbox wrapper (--sandbox)
 │   └── ui/
 │       ├── confirm.go            # TTY detection and confirmation prompt
 │       └── output.go             # findings display, formatting
@@ -464,7 +477,7 @@ safesh/
 |---|---|
 | `mvdan.cc/sh/v3` | Shell parser (AST) and syntax utilities. Powers all static analysis. |
 | `github.com/spf13/cobra` | CLI framework. Flag parsing, subcommands, help generation. |
-| `github.com/BurntSushi/toml` | Configuration file parsing. |
+| `github.com/pelletier/go-toml/v2` | Configuration file parsing. |
 | `golang.org/x/term` | TTY detection (determines whether to show interactive confirmation prompt). |
 
 All dependencies are chosen for stability and minimal transitive footprint. `mvdan.cc/sh/v3` is the only domain-specific dependency; the rest are standard CLI infrastructure.

--- a/docs/features.md
+++ b/docs/features.md
@@ -66,6 +66,7 @@ Categories:
 | **network** | `curl`/`wget`/`fetch` calls within the script and the domains they contact |
 | **obfuscation** | `eval`, `base64 -d | bash`, dynamic variable construction used in command execution |
 | **execution-chain** | Nested `curl \| bash` or `wget \| sh` patterns inside the script |
+| **homograph** | Bidi/isolate control characters, zero-width characters, and IDN-homograph URL hosts (mixed-script or non-ASCII labels) |
 
 Example output:
 
@@ -173,7 +174,7 @@ This is static analysis — it identifies `curl`/`wget` calls with literal URLs.
 
 ### 11. Environment Isolation
 
-`safesh` runs the script with a clean, minimal environment rather than inheriting the full shell environment. The inherited environment is stripped to a safe baseline (PATH, HOME, USER, SHELL, TERM, LANG) before execution.
+`safesh` runs the script with a clean, minimal environment rather than inheriting the full shell environment. The inherited environment is stripped to a safe baseline (`PATH`, `HOME`, `USER`, `LOGNAME`, `SHELL`, `TERM`, `LANG`, `LC_ALL`) before execution.
 
 This prevents scripts from accidentally or intentionally reading sensitive values from environment variables (API keys, tokens, credentials) that happen to be set in the user's session.
 
@@ -185,6 +186,30 @@ safesh --env MY_VAR https://example.com/install.sh
 
 ---
 
+### 12. Sandboxed Execution (Linux)
+
+`safesh --sandbox` runs the script inside a [bubblewrap](https://github.com/containers/bubblewrap) sandbox with a restricted filesystem view. Network access is blocked by default; pass `--sandbox-allow-net` to allow it. Linux only; requires `bwrap` to be installed.
+
+This is opt-in and intended for high-risk scripts where the user wants stronger isolation than environment stripping alone provides. macOS support and a Landlock-only fallback on Linux kernels where bubblewrap is unavailable are still future work (see Future Considerations).
+
+---
+
+### 13. CI / Non-Interactive Mode
+
+`safesh --ci` skips the confirmation prompt, prints findings as warnings, and exits non-zero only on actual execution failure (not on findings alone). Intended for automated environments — CI pipelines, provisioning scripts, agent toolchains — where there is no human at a TTY to respond to prompts.
+
+The findings report is still produced and still written to history. `--ci` does not suppress findings; it only changes how they gate execution.
+
+---
+
+### 14. Runtime Observation (Linux)
+
+`safesh --observe` runs the script under [`strace`](https://strace.io/) and reports the observed behavior afterward — files opened, network calls made, processes spawned. Linux only; requires `strace` to be installed.
+
+This is a sandboxed run by default (no confirmation prompt), intended as a complement to static analysis rather than a replacement. It catches dynamically constructed behavior that the static `network` finding cannot resolve, but it does not block: the script runs and the observation is reported alongside the findings. Use `--dry-run` if you want analysis without execution.
+
+---
+
 ## Future Considerations
 
 The following are intentionally out of scope for MVP. They are worth revisiting once core features are stable.
@@ -192,17 +217,11 @@ The following are intentionally out of scope for MVP. They are worth revisiting 
 ### Plugin / Hook Architecture
 A defined extension API allowing custom analysis modules, custom blocking rules, and custom audit backends. Valuable for power users and teams, but expensive to design well. A poorly designed plugin API becomes a maintenance burden and a new attack surface. Should emerge from real use cases rather than speculative design.
 
-### Sandboxed Execution
-`safesh --sandbox` using bubblewrap or Linux namespaces to run the script with a restricted filesystem view and optional network blocking. Strong isolation for high-risk scripts. Significant implementation complexity and limited portability (requires Linux kernel 5.13+ for Landlock; bubblewrap not available on macOS).
-
-### Dynamic Dry Run
-Running the script in a sandbox and reporting what it *actually* did (files created, network calls made, processes spawned) rather than what a static analysis predicts. Far more accurate than static dry run but requires the sandbox infrastructure above.
+### macOS Sandbox + Landlock Fallback
+`--sandbox` is shipped on Linux via bubblewrap (see feature 12). Still future: a `sandbox-exec` profile for macOS, and a Landlock-only fallback on Linux kernels where bubblewrap is unavailable.
 
 ### Team / Organizational Policy
 Centrally managed `safesh` policy (allowed domains, required findings categories that block execution, mandatory audit log forwarding) for organizations that want consistent enforcement across developers. Out of scope until the single-user experience is solid.
 
 ### GPG / Sigstore Integration
 Verifying scripts against a GPG signature or Sigstore transparency log entry. Addresses the authentication gap that integrity checking (feature 7) does not. Requires bootstrapping trust in the verification tooling — a hard problem that deserves its own design treatment.
-
-### CI / Non-Interactive Mode
-`safesh --ci` that runs without prompts, treats all findings as warnings (not blocking), and exits non-zero only on execution failure. Useful for automated environments but needs careful design to avoid becoming a way to silently bypass the tool's protections.

--- a/docs/index.html
+++ b/docs/index.html
@@ -554,7 +554,7 @@
 <section class="features">
   <div class="container">
     <h2>How it protects you</h2>
-    <p class="sub">Seven guarantees, zero configuration required.</p>
+    <p class="sub">Six guarantees, zero configuration required.</p>
     <div class="features-grid">
       <div class="feature-card">
         <div class="icon">⛓</div>


### PR DESCRIPTION
## Summary

Reconciles user-facing documentation with the current state of the code. Each item below names the source of truth that drove the edit.

### README.md
- Add the `homograph` row to the **Finding categories** table — source: `internal/finding/finding.go` (`AllCategories`).

### docs/features.md
- Add the `homograph` row to the section 4 categories table.
- Promote three items out of **Future Considerations** because they have shipped:
  - `--sandbox` / `--sandbox-allow-net` (Linux bubblewrap) → new feature 12, source: `internal/sandbox/`, flag in `cmd/safesh/main.go`.
  - `--ci` (non-interactive mode) → new feature 13, source: `cmd/safesh/main.go`.
  - `--observe` (strace runtime observation) → new feature 14, source: `internal/observer/`. Replaces the "Dynamic Dry Run" future entry; macOS `sandbox-exec` and a Landlock-only fallback remain future work and are noted as such.
- Fix feature 11 environment-isolation passthrough list — was `PATH, HOME, USER, SHELL, TERM, LANG`; the executor actually passes `PATH, HOME, USER, LOGNAME, SHELL, TERM, LANG, LC_ALL` (matches `docs/design.md` section 5).

### docs/design.md
- Add the `homograph` row to the section 4 **Finding Modules** table.
- Add `--ci`, `--sandbox`, `--sandbox-allow-net`, `--observe` rows to the section 8 flags table — source: `cmd/safesh/main.go`.
- Refresh the section 9 project structure: `internal/finding/` (the `Finding` / `Category` types now live in their own package to break an import cycle), `internal/observer/`, `internal/sandbox/`, `internal/integration/` (build-tag tests), and the new `homograph.go` / `helpers.go` analyzer modules.
- Fix the section 10 TOML dependency entry: `github.com/BurntSushi/toml` → `github.com/pelletier/go-toml/v2` (matches `go.mod`).

### docs/index.html
- "Seven guarantees" → "Six guarantees" — the features grid in that section actually has six cards.

## Test plan

- [x] `git diff --stat` reviewed — only docs touched, no code.
- [x] HTML diff manually inspected for tag balance.
- [x] All markdown table column counts unchanged.
- [x] No new categories invented; every drift maps back to a named source-of-truth file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)