### PR TITLE
docs(site): add feature comparison matrix and fix Checks nav

### DIFF
--- a/docs/checks.html
+++ b/docs/checks.html
@@ -404,9 +404,12 @@
       <span class="logo">safe<span>sh</span></span>
     </a>
     <nav>
-      <a href="./" class="active">Home</a>
+      <a href="./">Home</a>
+      <a href="checks.html" class="active">Checks</a>
+      <a href="comparison.html">Comparison</a>
       <a href="https://github.com/safesh/safesh">GitHub</a>
       <a href="https://github.com/safesh/safesh/releases">Releases</a>
+      <a href="https://github.com/safesh/safesh/issues">Issues</a>
       <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle light/dark mode" id="theme-btn">
         <svg id="icon-moon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79z"/></svg>
         <svg id="icon-sun" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" style="display:none"><path d="M12 17a5 5 0 1 0 0-10 5 5 0 0 0 0 10zm0-14a1 1 0 0 1 1 1v1a1 1 0 0 1-2 0V4a1 1 0 0 1 1-1zm0 16a1 1 0 0 1 1 1v1a1 1 0 0 1-2 0v-1a1 1 0 0 1 1-1zm9-9a1 1 0 0 1 0 2h-1a1 1 0 0 1 0-2h1zM4 12a1 1 0 0 1 0 2H3a1 1 0 0 1 0-2h1zm14.66-6.24a1 1 0 0 1 0 1.42l-.71.7a1 1 0 1 1-1.41-1.41l.7-.71a1 1 0 0 1 1.42 0zm-12.5 12.5a1 1 0 0 1 0 1.41l-.71.71a1 1 0 0 1-1.41-1.42l.71-.7a1 1 0 0 1 1.41 0zm12.5.71a1 1 0 0 1-1.42 0l-.7-.71a1 1 0 0 1 1.41-1.41l.71.7a1 1 0 0 1 0 1.42zM6.16 7.18a1 1 0 0 1-1.41 0l-.71-.7a1 1 0 0 1 1.42-1.42l.7.71a1 1 0 0 1 0 1.41z"/></svg>

--- a/docs/comparison.html
+++ b/docs/comparison.html
@@ -1,0 +1,663 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>safesh — feature comparison</title>
+  <link rel="icon" type="image/svg+xml" href="favicon.svg">
+  <meta name="description" content="Side-by-side feature comparison of safesh against vet, Tirith, fbash + Falco, and raw bash.">
+  <script>
+    // Apply saved theme before paint to prevent flash
+    (function() {
+      var saved = localStorage.getItem('theme');
+      var prefer = window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+      if ((saved || prefer) === 'light') document.documentElement.setAttribute('data-theme', 'light');
+    })();
+  </script>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg:        #0a0a0c;
+      --surface:   #16161f;
+      --border:    #2e2e3c;
+      --text:      #dddde8;
+      --heading:   #ffffff;
+      --muted:     #9aa0b0;
+      --accent:    #f59e0b;
+      --accent-dim:#7c4f05;
+      --green:     #4ade80;
+      --red:       #f87171;
+      --blue:      #60a5fa;
+      --code-bg:   #1c1c28;
+      --radius:    6px;
+      --mono: 'SF Mono', 'JetBrains Mono', 'Fira Code', 'Cascadia Code', ui-monospace, monospace;
+      --sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+    }
+
+    [data-theme="light"] {
+      --bg:        #fafafa;
+      --surface:   #f4f4f5;
+      --border:    #e4e4e7;
+      --text:      #18181b;
+      --heading:   #09090b;
+      --muted:     #71717a;
+      --accent:    #d97706;
+      --accent-dim:#fef3c7;
+      --green:     #16a34a;
+      --red:       #dc2626;
+      --blue:      #2563eb;
+      --code-bg:   #1a1a20;
+    }
+
+    html { scroll-behavior: smooth; }
+
+    body {
+      background: var(--bg);
+      color: var(--text);
+      font-family: var(--sans);
+      font-size: 16px;
+      line-height: 1.6;
+      -webkit-font-smoothing: antialiased;
+      transition: background 0.2s, color 0.2s;
+    }
+
+    a { color: var(--accent); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+
+    .container {
+      max-width: 980px;
+      margin: 0 auto;
+      padding: 0 24px;
+    }
+
+    header {
+      border-bottom: 1px solid var(--border);
+      padding: 18px 0;
+    }
+    header .container {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+    .logo {
+      font-family: var(--mono);
+      font-size: 1.1rem;
+      font-weight: 600;
+      color: var(--text);
+      letter-spacing: -0.02em;
+    }
+    .logo span { color: var(--accent); }
+    nav a {
+      font-size: 0.875rem;
+      color: var(--muted);
+      margin-left: 24px;
+    }
+    nav a:hover { color: var(--text); text-decoration: none; }
+    nav a.active { color: var(--text); }
+    .theme-toggle {
+      background: none;
+      border: 1px solid var(--border);
+      border-radius: 50%;
+      color: var(--muted);
+      cursor: pointer;
+      width: 32px;
+      height: 32px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      margin-left: 20px;
+      flex-shrink: 0;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .theme-toggle:hover { color: var(--text); border-color: var(--muted); }
+    .theme-toggle svg { width: 15px; height: 15px; fill: currentColor; }
+
+    /* ── Hero ── */
+    .hero {
+      padding: 64px 0 48px;
+      border-bottom: 1px solid var(--border);
+    }
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-family: var(--mono);
+      font-size: 0.75rem;
+      color: var(--accent);
+      background: color-mix(in srgb, var(--accent) 10%, transparent);
+      border: 1px solid color-mix(in srgb, var(--accent) 25%, transparent);
+      border-radius: 100px;
+      padding: 3px 10px;
+      margin-bottom: 24px;
+    }
+    h1 {
+      font-size: clamp(1.75rem, 4vw, 2.5rem);
+      font-weight: 700;
+      letter-spacing: -0.03em;
+      line-height: 1.15;
+      color: var(--heading);
+      margin-bottom: 18px;
+    }
+    h1 em {
+      font-style: normal;
+      color: var(--accent);
+    }
+    .hero p {
+      font-size: 1.05rem;
+      color: var(--muted);
+      max-width: 680px;
+    }
+    .hero p + p { margin-top: 12px; }
+
+    /* ── Tools list ── */
+    .tools {
+      padding: 36px 0 8px;
+      border-bottom: 1px solid var(--border);
+    }
+    .tools h2 {
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--muted);
+      margin-bottom: 16px;
+    }
+    .tool-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+      gap: 14px;
+      padding-bottom: 32px;
+    }
+    .tool-card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 14px 16px;
+    }
+    .tool-card .name {
+      font-family: var(--mono);
+      font-size: 0.95rem;
+      font-weight: 600;
+      color: var(--heading);
+      margin-bottom: 4px;
+    }
+    .tool-card .name a {
+      color: var(--heading);
+      border-bottom: 1px dotted var(--border);
+    }
+    .tool-card .name a:hover {
+      color: var(--accent);
+      text-decoration: none;
+      border-bottom-color: var(--accent);
+    }
+    .tool-card p {
+      font-size: 0.82rem;
+      color: var(--muted);
+      line-height: 1.5;
+    }
+
+    /* ── Matrix ── */
+    .matrix {
+      padding: 40px 0 56px;
+    }
+    .matrix h2 {
+      font-size: 1.375rem;
+      font-weight: 600;
+      letter-spacing: -0.02em;
+      color: var(--heading);
+      margin-bottom: 8px;
+    }
+    .matrix .sub {
+      font-size: 0.95rem;
+      color: var(--muted);
+      margin-bottom: 24px;
+      max-width: 680px;
+    }
+
+    .table-scroll {
+      overflow-x: auto;
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      background: var(--surface);
+    }
+    table.matrix-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.875rem;
+      min-width: 720px;
+    }
+    table.matrix-table th,
+    table.matrix-table td {
+      padding: 10px 14px;
+      text-align: left;
+      border-bottom: 1px solid var(--border);
+      vertical-align: top;
+    }
+    table.matrix-table thead th {
+      font-size: 0.78rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: var(--muted);
+      background: color-mix(in srgb, var(--border) 35%, var(--surface));
+      position: sticky;
+      top: 0;
+    }
+    table.matrix-table thead th a {
+      color: var(--text);
+      border-bottom: 1px dotted var(--border);
+    }
+    table.matrix-table thead th a:hover {
+      color: var(--accent);
+      text-decoration: none;
+      border-bottom-color: var(--accent);
+    }
+    table.matrix-table thead th.tool-self {
+      color: var(--accent);
+    }
+    table.matrix-table tbody tr:last-child td { border-bottom: none; }
+    table.matrix-table tbody tr:hover {
+      background: color-mix(in srgb, var(--accent) 4%, transparent);
+    }
+    table.matrix-table td.cap {
+      color: var(--text);
+      font-weight: 500;
+      width: 30%;
+      min-width: 220px;
+    }
+    table.matrix-table td.cell {
+      color: var(--muted);
+      white-space: nowrap;
+    }
+    table.matrix-table td.cell.yes {
+      color: var(--green);
+      font-weight: 600;
+    }
+    table.matrix-table td.cell.no {
+      color: var(--muted);
+    }
+    table.matrix-table td.cell.partial {
+      color: var(--accent);
+      font-weight: 500;
+    }
+    table.matrix-table td.cell .qual {
+      color: var(--muted);
+      font-weight: 400;
+      font-size: 0.82rem;
+      margin-left: 4px;
+    }
+    table.matrix-table td.cell code {
+      font-family: var(--mono);
+      font-size: 0.78rem;
+      color: inherit;
+      background: color-mix(in srgb, currentColor 10%, transparent);
+      border: 1px solid color-mix(in srgb, currentColor 22%, transparent);
+      border-radius: 3px;
+      padding: 0 4px;
+    }
+
+    .legend {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 18px;
+      margin-top: 18px;
+      font-size: 0.82rem;
+      color: var(--muted);
+    }
+    .legend .swatch {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+    }
+    .legend .swatch::before {
+      content: '';
+      display: inline-block;
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      background: currentColor;
+    }
+    .legend .swatch.yes { color: var(--green); }
+    .legend .swatch.partial { color: var(--accent); }
+    .legend .swatch.no { color: var(--muted); }
+
+    .closing {
+      padding: 48px 0 64px;
+      border-top: 1px solid var(--border);
+    }
+    .closing blockquote {
+      border-left: 3px solid var(--accent);
+      padding-left: 20px;
+      color: var(--muted);
+      font-size: 1.02rem;
+      font-style: italic;
+      line-height: 1.7;
+    }
+    .closing blockquote strong {
+      color: var(--text);
+      font-style: normal;
+    }
+    .closing p {
+      margin-top: 18px;
+      font-size: 0.92rem;
+      color: var(--muted);
+    }
+
+    footer {
+      padding: 32px 0;
+      border-top: 1px solid var(--border);
+    }
+    footer .container {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      flex-wrap: wrap;
+      gap: 12px;
+    }
+    footer p {
+      font-size: 0.825rem;
+      color: var(--muted);
+    }
+    footer a { color: var(--muted); }
+    footer a:hover { color: var(--text); }
+
+    @media (max-width: 540px) {
+      .hero { padding: 40px 0 32px; }
+      header .container { flex-direction: column; align-items: flex-start; gap: 12px; }
+      nav a:first-child { margin-left: 0; }
+      footer .container { flex-direction: column; }
+    }
+  </style>
+</head>
+<body>
+
+<header>
+  <div class="container">
+    <a href="./" style="display:inline-flex;align-items:center;text-decoration:none;">
+      <img src="icon.svg" width="28" height="28" alt="" style="vertical-align:middle;margin-right:8px;">
+      <span class="logo">safe<span>sh</span></span>
+    </a>
+    <nav>
+      <a href="./">Home</a>
+      <a href="checks.html">Checks</a>
+      <a href="comparison.html" class="active">Comparison</a>
+      <a href="https://github.com/safesh/safesh">GitHub</a>
+      <a href="https://github.com/safesh/safesh/releases">Releases</a>
+      <a href="https://github.com/safesh/safesh/issues">Issues</a>
+      <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle light/dark mode" id="theme-btn">
+        <svg id="icon-moon" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79z"/></svg>
+        <svg id="icon-sun" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" style="display:none"><path d="M12 17a5 5 0 1 0 0-10 5 5 0 0 0 0 10zm0-14a1 1 0 0 1 1 1v1a1 1 0 0 1-2 0V4a1 1 0 0 1 1-1zm0 16a1 1 0 0 1 1 1v1a1 1 0 0 1-2 0v-1a1 1 0 0 1 1-1zm9-9a1 1 0 0 1 0 2h-1a1 1 0 0 1 0-2h1zM4 12a1 1 0 0 1 0 2H3a1 1 0 0 1 0-2h1zm14.66-6.24a1 1 0 0 1 0 1.42l-.71.7a1 1 0 1 1-1.41-1.41l.7-.71a1 1 0 0 1 1.42 0zm-12.5 12.5a1 1 0 0 1 0 1.41l-.71.71a1 1 0 0 1-1.41-1.42l.71-.7a1 1 0 0 1 1.41 0zm12.5.71a1 1 0 0 1-1.42 0l-.7-.71a1 1 0 0 1 1.41-1.41l.71.7a1 1 0 0 1 0 1.42zM6.16 7.18a1 1 0 0 1-1.41 0l-.71-.7a1 1 0 0 1 1.42-1.42l.7.71a1 1 0 0 1 0 1.41z"/></svg>
+      </button>
+    </nav>
+  </div>
+</header>
+
+<section class="hero">
+  <div class="container">
+    <div class="badge">feature comparison</div>
+    <h1>How safesh compares <em>to other tools</em></h1>
+    <p>
+      Several projects have taken aim at the <code>curl | bash</code> problem from different
+      angles — fetch-and-diff, shell-hook interception, runtime sandboxing, or just running the
+      script as-is. This page lays out, capability by capability, what each one actually ships
+      today.
+    </p>
+    <p>
+      Headers link to each project so you can verify the claims yourself. If anything below
+      looks wrong or out of date, please <a href="https://github.com/safesh/safesh/issues">open
+      an issue</a> — we'd rather correct the table than misrepresent a peer tool.
+    </p>
+  </div>
+</section>
+
+<section class="tools">
+  <div class="container">
+    <h2>Tools in this comparison</h2>
+    <div class="tool-grid">
+      <div class="tool-card">
+        <div class="name"><a href="https://github.com/safesh/safesh">safesh</a></div>
+        <p>Drop-in replacement for <code>bash</code> in the curl-pipe-bash pattern. Buffers the
+        script, runs categorized AST analysis, injects strict mode, records history.</p>
+      </div>
+      <div class="tool-card">
+        <div class="name"><a href="https://github.com/vet-run/vet">vet</a></div>
+        <p>Fetch + diff against last run + ShellCheck + confirm. Two flags total. The most direct
+        peer; flagship feature is the diff signal.</p>
+      </div>
+      <div class="tool-card">
+        <div class="name"><a href="https://github.com/sheeki03/tirith">Tirith</a></div>
+        <p>Shell-hook based interception (<a href="https://tirith.sh/">tirith.sh</a>) with a large
+        rule pack across ~15 categories, threat-intel updates, and an MCP / AI-agent integration.</p>
+      </div>
+      <div class="tool-card">
+        <div class="name"><a href="https://www.sysdig.com/blog/friends-dont-let-friends-curl-bash">fbash + Falco</a></div>
+        <p>Sysdig's runtime approach: wrap the install in a session leader and use eBPF rules
+        (Falco) to flag/block writes outside install paths and other escape attempts.</p>
+      </div>
+      <div class="tool-card">
+        <div class="name"><a href="https://www.gnu.org/software/bash/">raw bash</a></div>
+        <p>The baseline — what <code>curl … | bash</code> does today with no protection layer.
+        Included as a reference column, not because it's a competitor.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="matrix">
+  <div class="container">
+    <h2>Feature matrix</h2>
+    <p class="sub">
+      Compact comparison of what each tool actually ships today. "Yes" means the capability is
+      shipped and on by default; "partial" means the tool covers part of the capability or
+      requires extra setup; "no" means the capability is absent.
+    </p>
+
+    <div class="table-scroll">
+      <table class="matrix-table">
+        <thead>
+          <tr>
+            <th>Capability</th>
+            <th class="tool-self"><a href="https://github.com/safesh/safesh">safesh</a> <span style="font-weight:400;color:var(--muted);">(now)</span></th>
+            <th><a href="https://github.com/vet-run/vet">vet</a></th>
+            <th><a href="https://github.com/sheeki03/tirith">Tirith</a></th>
+            <th><a href="https://www.sysdig.com/blog/friends-dont-let-friends-curl-bash">fbash + Falco</a></th>
+            <th><a href="https://www.gnu.org/software/bash/">raw bash</a></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="cap">Full buffering before exec</td>
+            <td class="cell yes">yes</td>
+            <td class="cell yes">yes</td>
+            <td class="cell yes">yes <span class="qual">(run cmd)</span></td>
+            <td class="cell no">no</td>
+            <td class="cell no">no</td>
+          </tr>
+          <tr>
+            <td class="cap">Strict-mode injection (<code>set -euo pipefail</code>)</td>
+            <td class="cell yes">yes</td>
+            <td class="cell no">no</td>
+            <td class="cell no">no</td>
+            <td class="cell no">no</td>
+            <td class="cell no">no</td>
+          </tr>
+          <tr>
+            <td class="cap">Categorized findings (AST)</td>
+            <td class="cell yes">yes <span class="qual">(8 cats)</span></td>
+            <td class="cell partial">via shellcheck</td>
+            <td class="cell yes">yes <span class="qual">(~80 rules / 15 cats)</span></td>
+            <td class="cell no">n/a <span class="qual">(runtime)</span></td>
+            <td class="cell no">no</td>
+          </tr>
+          <tr>
+            <td class="cap">Diff against previous run</td>
+            <td class="cell no">no</td>
+            <td class="cell yes">yes</td>
+            <td class="cell no">no</td>
+            <td class="cell no">no</td>
+            <td class="cell no">no</td>
+          </tr>
+          <tr>
+            <td class="cap">Env stripping to baseline</td>
+            <td class="cell yes">yes</td>
+            <td class="cell no">no</td>
+            <td class="cell no">no</td>
+            <td class="cell no">no</td>
+            <td class="cell no">no</td>
+          </tr>
+          <tr>
+            <td class="cap">Integrity (SHA-256, sibling files)</td>
+            <td class="cell yes">yes <span class="qual">(URL mode)</span></td>
+            <td class="cell no">no</td>
+            <td class="cell no">no</td>
+            <td class="cell no">no</td>
+            <td class="cell no">no</td>
+          </tr>
+          <tr>
+            <td class="cap">Signature verification (Sigstore / GPG)</td>
+            <td class="cell no">no</td>
+            <td class="cell no">no</td>
+            <td class="cell no">no</td>
+            <td class="cell no">no</td>
+            <td class="cell no">no</td>
+          </tr>
+          <tr>
+            <td class="cap">History &amp; audit log</td>
+            <td class="cell yes">yes</td>
+            <td class="cell partial">cache only</td>
+            <td class="cell yes">logs</td>
+            <td class="cell partial">via Falco</td>
+            <td class="cell no">no</td>
+          </tr>
+          <tr>
+            <td class="cap">Network-target inventory</td>
+            <td class="cell yes">yes <span class="qual">(static + runtime via <code>--observe</code>)</span></td>
+            <td class="cell no">no</td>
+            <td class="cell partial">partial</td>
+            <td class="cell partial">runtime</td>
+            <td class="cell no">no</td>
+          </tr>
+          <tr>
+            <td class="cap">ANSI / bidi / zero-width detection</td>
+            <td class="cell yes">yes</td>
+            <td class="cell no">no</td>
+            <td class="cell yes">yes</td>
+            <td class="cell no">no</td>
+            <td class="cell no">no</td>
+          </tr>
+          <tr>
+            <td class="cap">Homograph URL detection</td>
+            <td class="cell yes">yes</td>
+            <td class="cell no">no</td>
+            <td class="cell yes">yes</td>
+            <td class="cell no">no</td>
+            <td class="cell no">no</td>
+          </tr>
+          <tr>
+            <td class="cap">Sandboxed execution</td>
+            <td class="cell yes">yes <span class="qual">(Linux, bwrap)</span></td>
+            <td class="cell no">no</td>
+            <td class="cell no">no</td>
+            <td class="cell yes">yes <span class="qual">(Linux)</span></td>
+            <td class="cell no">no</td>
+          </tr>
+          <tr>
+            <td class="cap">Shell-hook / passive coverage</td>
+            <td class="cell no">no</td>
+            <td class="cell no">no</td>
+            <td class="cell yes">yes</td>
+            <td class="cell no">no</td>
+            <td class="cell no">n/a</td>
+          </tr>
+          <tr>
+            <td class="cap">MCP / AI-agent integration</td>
+            <td class="cell no">no</td>
+            <td class="cell no">no</td>
+            <td class="cell yes">yes</td>
+            <td class="cell no">no</td>
+            <td class="cell no">no</td>
+          </tr>
+          <tr>
+            <td class="cap">Threat-intel rule pack updates</td>
+            <td class="cell no">no</td>
+            <td class="cell no">no</td>
+            <td class="cell yes">yes <span class="qual">(signed)</span></td>
+            <td class="cell partial">via Falco</td>
+            <td class="cell no">no</td>
+          </tr>
+          <tr>
+            <td class="cap">Cross-platform (macOS / Linux / WSL)</td>
+            <td class="cell yes">yes</td>
+            <td class="cell yes">yes</td>
+            <td class="cell yes">yes</td>
+            <td class="cell partial">Linux only</td>
+            <td class="cell yes">yes</td>
+          </tr>
+          <tr>
+            <td class="cap">Dry-run</td>
+            <td class="cell yes">yes</td>
+            <td class="cell partial">partial</td>
+            <td class="cell yes">yes <span class="qual">(check)</span></td>
+            <td class="cell no">no</td>
+            <td class="cell no">no</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <div class="legend">
+      <span class="swatch yes">yes — shipped and on by default</span>
+      <span class="swatch partial">partial — covers part, or requires extra setup</span>
+      <span class="swatch no">no — not present</span>
+    </div>
+  </div>
+</section>
+
+<section class="closing">
+  <div class="container">
+    <blockquote>
+      <strong>Different bets, not strict ranking.</strong>
+      Each tool here picks a different point on the curve: vet bets on minimal flags and the
+      diff signal; Tirith bets on always-on shell-hook coverage and a large signed rule pack;
+      fbash + Falco bet on runtime containment via eBPF; safesh bets on static AST analysis,
+      strict mode, and a small surface that runs anywhere bash does. Pick what fits your
+      threat model.
+    </blockquote>
+    <p>
+      Want to suggest a tool we missed, or a row that doesn't reflect reality?
+      <a href="https://github.com/safesh/safesh/issues">Open an issue</a> — corrections welcome.
+    </p>
+  </div>
+</section>
+
+<footer>
+  <div class="container">
+    <p>Released under the <a href="https://github.com/safesh/safesh/blob/main/LICENSE">MIT License</a></p>
+    <p><a href="https://github.com/safesh/safesh">github.com/safesh/safesh</a></p>
+  </div>
+</footer>
+
+<script>
+  function syncIcon() {
+    var light = document.documentElement.getAttribute('data-theme') === 'light';
+    document.getElementById('icon-moon').style.display = light ? 'none' : '';
+    document.getElementById('icon-sun').style.display  = light ? ''     : 'none';
+  }
+
+  function toggleTheme() {
+    var light = document.documentElement.getAttribute('data-theme') === 'light';
+    if (light) {
+      document.documentElement.removeAttribute('data-theme');
+      localStorage.setItem('theme', 'dark');
+    } else {
+      document.documentElement.setAttribute('data-theme', 'light');
+      localStorage.setItem('theme', 'light');
+    }
+    syncIcon();
+  }
+
+  syncIcon();
+</script>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -456,6 +456,7 @@
     </a>
     <nav>
       <a href="checks.html">Checks</a>
+      <a href="comparison.html">Comparison</a>
       <a href="https://github.com/safesh/safesh">GitHub</a>
       <a href="https://github.com/safesh/safesh/releases">Releases</a>
       <a href="https://github.com/safesh/safesh/issues">Issues</a>
@@ -554,7 +555,7 @@
 <section class="features">
   <div class="container">
     <h2>How it protects you</h2>
-    <p class="sub">Seven guarantees, zero configuration required.</p>
+    <p class="sub">Six guarantees, zero configuration required.</p>
     <div class="features-grid">
       <div class="feature-card">
         <div class="icon">⛓</div>


### PR DESCRIPTION
## Summary
- Adds a new **Comparison** page (`docs/comparison.html`) presenting the safesh-vs-peers feature matrix sourced from `.local/feature-list.html`, with each tool column header linked to the project being compared (vet, Tirith, fbash + Falco, raw bash).
- Fixes the **Checks** page nav, which was missing the **Issues** link present on the home page; both pages now expose the same set of nav links plus the new **Comparison** entry.

## Test plan
- [ ] Open `docs/index.html`, `docs/checks.html`, and `docs/comparison.html` in a browser; confirm the top nav is consistent on each page (Home / Checks / Comparison / GitHub / Releases / Issues), with the active page highlighted.
- [ ] On the Comparison page, verify every tool column header links to the right project.
- [ ] Verify dark/light theme toggle works on the new page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)