### PR TITLE
security(release): SLSA provenance and SBOM generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,12 +6,17 @@ on:
       - "v*"
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2
@@ -38,3 +43,35 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+
+      - name: Collect artifact hashes for SLSA provenance
+        id: hash
+        run: |
+          set -euo pipefail
+          files=$(ls dist/*.tar.gz dist/*.zip dist/checksums.txt 2>/dev/null || true)
+          if [ -z "$files" ]; then
+            echo "hashes=" >> "$GITHUB_OUTPUT"
+          else
+            hashes=$(echo "$files" | xargs sha256sum | base64 -w0)
+            echo "hashes=$hashes" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@f6c3d0fe42c3cf876e3462574e4c9416b5e0f07a # v0.9.0
+        with:
+          format: spdx-json
+          output-file: sbom.spdx.json
+          upload-release-assets: true
+
+  provenance:
+    name: SLSA provenance
+    needs: [release]
+    if: ${{ needs.release.outputs.hashes != '' }}
+    permissions:
+      actions: read
+      id-token: write
+      contents: write
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@f7dd8c54c2067bafc12ca7a55595d5ee9b75204a # v2.1.0
+    with:
+      base64-subjects: ${{ needs.release.outputs.hashes }}
+      upload-assets: true


### PR DESCRIPTION
## Summary

- SLSA level 3 provenance via `slsa-framework/slsa-github-generator` — generates signed attestations for all GoReleaser artifacts and uploads them to the GitHub release
- SBOM in SPDX-JSON format via `anchore/sbom-action` — attached automatically to the GitHub release
- Workflow-level `permissions` narrowed to `contents: read`; `contents: write` and `id-token: write` scoped to job level only

## Test plan

- [ ] CI passes on this PR (no tag triggered, so provenance job is not exercised here)
- [ ] Verify on next `vX.Y.Z` tag: release assets include `.intoto.jsonl` attestation and `sbom.spdx.json`